### PR TITLE
Feat/custom strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Keep-Alive: timeout=5
 | projectName     | `UNLEASH_PROJECT_NAME`    | `undefined`   | no       | The projectName (id) to fetch feature toggles for. The proxy will only return know about feature toggles that belongs to the project, if specified.  | | 
 | logger          | n/a                       | SimpleLogger  | no       | Register a custom logger. | 
 | logLevel        | `LOG_LEVEL `              | "warn"        | no       | Used to set logLevel. Supported options: "debug", "info", "warn", "error" and "fatal | 
-
+| customStrategies| `UNLEASH_CUSTOM_STRATEGIES_FILE` | []	  | no		 | Use this option to inject implementation of custom activation strategies. If you are using `UNLEASH_CUSTOM_STRATEGIES_FILE` you need to provide a valid path to a javascript files which exports an array of custom activation strategies and the SDK will automatically load these | 
 
 ### Run with Node.js:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@unleash/proxy",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unleash/proxy",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "The Open-Soruce Unleash Proxy",
   "main": "dist/index.js",
   "scripts": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -71,6 +71,7 @@ class Client extends EventEmitter implements IClient {
             environment: this.environment,
             refreshInterval: config.refreshInterval,
             projectName: config.projectName,
+            strategies: config.customStrategies,
             disableMetrics: true,
             customHeadersFunction,
         });

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,9 +1,11 @@
+import { Strategy } from 'unleash-client';
 import { Logger, LogLevel, SimpleLogger } from './logger';
 
 export interface IProxyOption {
     unleashUrl?: string;
     unleashApiToken?: string;
     unleashAppName?: string;
+    customStrategies?: Strategy[];
     proxySecrets?: string[];
     proxyPort?: number;
     proxyBasePath?: string;
@@ -19,6 +21,7 @@ export interface IProxyConfig {
     unleashUrl: string;
     unleashApiToken: string;
     unleashAppName: string;
+    customStrategies?: Strategy[];
     proxySecrets: string[];
     proxyBasePath: string;
     refreshInterval: number;
@@ -48,6 +51,15 @@ function safeNumber(envVar: string | undefined, defaultVal: number): number {
     }
 }
 
+function loadCustomStrategies(path?: string): Strategy[] | undefined {
+    if (path) {
+        // eslint-disable-next-line
+        const strategies = require(path) as Strategy[];
+        return strategies;
+    }
+    return undefined;
+}
+
 export function createProxyConfig(option: IProxyOption): IProxyConfig {
     const unleashUrl = option.unleashUrl || process.env.UNLEASH_URL;
     if (!unleashUrl) {
@@ -63,6 +75,10 @@ export function createProxyConfig(option: IProxyOption): IProxyConfig {
             'You must specify the unleashApiToken option (UNLEASH_API_TOKEN)',
         );
     }
+
+    const customStrategies =
+        option.customStrategies ||
+        loadCustomStrategies(process.env.UNLEASH_CUSTOM_STRATEGIES_FILE);
 
     const proxySecrets =
         option.proxySecrets ||
@@ -82,6 +98,7 @@ export function createProxyConfig(option: IProxyOption): IProxyConfig {
             option.proxyBasePath ||
             process.env.UNLEASH_APP_NAME ||
             'unleash-proxy',
+        customStrategies,
         proxySecrets,
         proxyBasePath:
             option.proxyBasePath || process.env.PROXY_BASE_PATH || '',

--- a/src/examples/custom-strategies.js
+++ b/src/examples/custom-strategies.js
@@ -7,7 +7,7 @@ class TestStrat extends Strategy {
     }
 
     isEnabled(parameters, context) {
-        // do something cool with params and context. 
+        // do something cool with params and context.
         return true;
     }
 }

--- a/src/examples/custom-strategies.js
+++ b/src/examples/custom-strategies.js
@@ -1,0 +1,15 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+const { Strategy } = require('unleash-client');
+
+class TestStrat extends Strategy {
+    constructor() {
+        super('FromFile');
+    }
+
+    isEnabled(parameters, context) {
+        // do something cool with params and context. 
+        return true;
+    }
+}
+
+module.exports = [new TestStrat()];

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import { Strategy } from 'unleash-client';
 import { createProxyConfig } from '../config';
 
@@ -70,7 +71,8 @@ test('should load custom activation strategy', () => {
 });
 
 test('should load custom activation strategy from file', () => {
-    process.env.UNLEASH_CUSTOM_STRATEGIES_FILE = `${__dirname}/../examples/custom-strategies.js`;
+    const base = path.resolve('');
+    process.env.UNLEASH_CUSTOM_STRATEGIES_FILE = `${base}/src/examples/custom-strategies.js`;
 
     const config = createProxyConfig({
         unleashUrl: 'some',

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -70,7 +70,7 @@ test('should load custom activation strategy', () => {
 });
 
 test('should load custom activation strategy from file', () => {
-    process.env.UNLEASH_CUSTOM_STRATEGIES_FILE = `${__dirname}../../examples/custom-strategies.js`;
+    process.env.UNLEASH_CUSTOM_STRATEGIES_FILE = `${__dirname}/../examples/custom-strategies.js`;
 
     const config = createProxyConfig({
         unleashUrl: 'some',

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -1,3 +1,4 @@
+import { Strategy } from 'unleash-client';
 import { createProxyConfig } from '../config';
 
 test('should require "unleashUrl', () => {
@@ -39,4 +40,50 @@ test('should allow options via env', () => {
     delete process.env.UNLEASH_URL;
     delete process.env.UNLEASH_API_TOKEN;
     delete process.env.UNLEASH_PROXY_SECRETS;
+});
+
+test('should load custom activation strategy', () => {
+    class TestStrat extends Strategy {
+        constructor() {
+            super('TestStrat');
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        isEnabled(parameters: any, context: any) {
+            return true;
+        }
+    }
+
+    const config = createProxyConfig({
+        unleashUrl: 'some',
+        unleashApiToken: 'some',
+        proxySecrets: ['s1'],
+        customStrategies: [new TestStrat()],
+    });
+
+    expect(config.customStrategies?.length).toBe(1);
+    if (config.customStrategies) {
+        expect(config.customStrategies[0].name).toBe('TestStrat');
+    } else {
+        throw new Error('Expected custom strategy to be set!');
+    }
+});
+
+test('should load custom activation strategy from file', () => {
+    process.env.UNLEASH_CUSTOM_STRATEGIES_FILE = `${__dirname}../../examples/custom-strategies.js`;
+
+    const config = createProxyConfig({
+        unleashUrl: 'some',
+        unleashApiToken: 'some',
+        proxySecrets: ['s1'],
+    });
+
+    expect(config.customStrategies?.length).toBe(1);
+    if (config.customStrategies) {
+        expect(config.customStrategies[0].name).toBe('FromFile');
+    } else {
+        throw new Error('Expected custom strategy to be set!');
+    }
+
+    delete process.env.UNLEASH_CUSTOM_STRATEGIES_FILE;
 });


### PR DESCRIPTION
Will allow the user to provide custom activation stratgies. 

## Docker
For Docker you will go through the env variable:
`UNLEASH_CUSTOM_STRATEGIES_FILE` - which should point to the full path of a file mounted in the docker container that looks something like this:

```js
const { Strategy } = require('unleash-client');

class TestStrat extends Strategy {
    constructor() {
        super('TestStrat');
    }

    isEnabled(parameters, context) {
        //do something cool with params and context. 
        return true;
    }
}

module.exports = [new TestStrat()];
```

We probably should have some examples on how to actually mount the files needed in to the docker image. 

## npm
If the user consumes the proxy via npm you can simply provide the strategies array as you would with the [node-client-sdk](https://github.com/Unleash/unleash-client-node):

```js
const app = createApp({
    unleashUrl: 'https://app.unleash-hosted.com/demo/api/',
    unleashApiToken: 'token',
    proxySecrets: ['s1'],
    refreshInterval: 1000,
    customStrategies: [new TestStrat()],
    // logLevel: 'info',
    // projectName: 'order-team', // optional
    // environment: 'development',
});
```

## Todo

- [x] Write unit tests for loading custom strategies

fixes: #6 