### PR TITLE
Fix typo in `docker pull` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The easies way to run Unleash is via Docker. We have published a [docker image o
 **Step 1: Pull**
 
 ```bash
-docker pull docker pull unleashorg/unleash-proxy
+docker pull unleashorg/unleash-proxy
 ```
 
 **Step 2: Start**


### PR DESCRIPTION
There's an extra `docker pull` in the command 😄 