### PR TITLE
Build multi-arch Docker container to support arm64 and amd64

### DIFF
--- a/.github/workflows/push-docker-releases.yml
+++ b/.github/workflows/push-docker-releases.yml
@@ -35,12 +35,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-     # - name: Login to ghcr
-     #   uses: docker/login-action@v1
-     #   with:
-     #     registry: ghcr.io
-     #     username: ${{ github.repository_owner }}
-     #     password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to ghcr
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2


### PR DESCRIPTION
Hi, 

Currently, your images are being published with amd64 support, but with the new M1 macs and other arm-based cpus such as AWS Graviton servers.

This small change will publish your image with amd64 and amd64 support. 

When this is merged in I will be able to remove my fork and Dockerhub containers.