### PR TITLE
feat: additional possibility to customize header for proxy secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Keep-Alive: timeout=5
 | -------------   |----------------------     |----------     |:--------:|---------------|
 | unleashUrl      |`UNLEASH_URL`              | n/a           | yes      | API Url to the Unleash instance to connect to |
 | unleashApiToken | `UNLEASH_API_TOKEN`       | n/a           | yes      | API token (client) needed to connect to Unleash API. |
-| clientKeys      | `UNLEASH_CLIENT_KEYS`     | n/a           | yes      | List of _client keys_ the Unleash proxy accepts. Proxy SDKs needs to set the _client key_ as the `Authorization` header (or another specified under `clientKeysHeaderName` option) when interacting with the Unleash proxy | 
+| clientKeys      | `UNLEASH_CLIENT_KEYS`     | n/a           | yes      | List of client keys that the proxy should accept. When querying the proxy, Proxy SDKs must set the request's _client keys header_ to one of these values. The default client keys header is `Authorization`. | 
 | proxySecrets    | `UNLEASH_PROXY_SECRETS`   | n/a           | no      | Deprecated alias for `clientKeys`. Please use `clientKeys` instead. | 
 | proxyPort       | `PORT`                    | 3000          | no       | The port where the proxy should listen. | 
 | proxyBasePath   | `PROXY_BASE_PATH`         |"/proxy"       | no       | The base path to run the proxy from. Defaults to "/proxy" |

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Keep-Alive: timeout=5
 | -------------   |----------------------     |----------     |:--------:|---------------|
 | unleashUrl      |`UNLEASH_URL`              | n/a           | yes      | API Url to the Unleash instance to connect to |
 | unleashApiToken | `UNLEASH_API_TOKEN`       | n/a           | yes      | API token (client) needed to connect to Unleash API. |
-| proxySecrets    | `UNLEASH_PROXY_SECRETS`   | n/a           | yes      | List of proxy secrets the proxy accept. Proxy SDKs needs to set the Proxy secret as the `Authorization` header (or another specified under `proxyHeaderName` option) when querying the proxy | 
+| proxySecrets    | `UNLEASH_PROXY_SECRETS`   | n/a           | yes      | List of proxy secrets the proxy accept. Proxy SDKs needs to set the Proxy secret as the `Authorization` header (or another specified under `proxySecretHeaderName` option) when querying the proxy | 
 | proxyPort       | `PORT`                    | 3000          | no       | The port where the proxy should listen. | 
 | proxyBasePath   | `PROXY_BASE_PATH`         |"/proxy"       | no       | The base path to run the proxy from. Defaults to "/proxy" |
 | unleashAppName  | `UNLEASH_APP_NAME`        |"unleash-proxy"| no       | App name to used when registering with Unleash |
@@ -122,7 +122,7 @@ Keep-Alive: timeout=5
 | trustProxy      | `TRUST_PROXY `            | `false`       | no       | By enabling the trustProxy option, Unleash Proxy will have knowledge that it's sitting behind a proxy and that the X-Forwarded-* header fields may be trusted, which otherwise may be easily spoofed. The proxy will automatically enrich the ip address in the Unleash Context. Can either be `true/false` (Trust all proxies), trust only given IP/CIDR (e.g. `'127.0.0.1'`) as a `string`. May be a list of comma separated values (e.g. `'127.0.0.1,192.168.1.1/24'` | 
 | namePrefix        | `UNLEASH_NAME_PREFIX`              | undefined        | no       | Used to filter features by using prefix when requesting backend values. | 
 | tags        | `UNLEASH_TAGS`              | undefined        | no       | Used to filter features by using tags set for features. Format should be `tagName:tagValue,tagName2:tagValue2` | 
-| proxyHeaderName        | `PROXY_HEADER_NAME`              | "authorization"        | no       | Used to specify under which header will be passed proxy secret | 
+| proxySecretHeaderName        | `PROXY_SECRET_HEADER_NAME`              | "authorization"        | no       | Used to specify under which header will be passed proxy secret | 
 
 ### Run with Node.js:
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ Keep-Alive: timeout=5
 | -------------   |----------------------     |----------     |:--------:|---------------|
 | unleashUrl      |`UNLEASH_URL`              | n/a           | yes      | API Url to the Unleash instance to connect to |
 | unleashApiToken | `UNLEASH_API_TOKEN`       | n/a           | yes      | API token (client) needed to connect to Unleash API. |
-| proxySecrets    | `UNLEASH_PROXY_SECRETS`   | n/a           | yes      | List of proxy secrets the proxy accept. Proxy SDKs needs to set the Proxy secret as the `Authorization` header (or another specified under `proxySecretHeaderName` option) when querying the proxy | 
+| clientKeys      | `UNLEASH_CLIENT_KEYS`     | n/a           | yes      | List of proxy secrets the proxy accept. Proxy SDKs needs to set the Proxy secret as the `Authorization` header (or another specified under `clientKeysHeaderName` option) when querying the proxy | 
+| proxySecrets    | `UNLEASH_PROXY_SECRETS`   | n/a           | no      | Alias for `clientKeys` in order to keep backward compatibility | 
 | proxyPort       | `PORT`                    | 3000          | no       | The port where the proxy should listen. | 
 | proxyBasePath   | `PROXY_BASE_PATH`         |"/proxy"       | no       | The base path to run the proxy from. Defaults to "/proxy" |
 | unleashAppName  | `UNLEASH_APP_NAME`        |"unleash-proxy"| no       | App name to used when registering with Unleash |
@@ -122,7 +123,7 @@ Keep-Alive: timeout=5
 | trustProxy      | `TRUST_PROXY `            | `false`       | no       | By enabling the trustProxy option, Unleash Proxy will have knowledge that it's sitting behind a proxy and that the X-Forwarded-* header fields may be trusted, which otherwise may be easily spoofed. The proxy will automatically enrich the ip address in the Unleash Context. Can either be `true/false` (Trust all proxies), trust only given IP/CIDR (e.g. `'127.0.0.1'`) as a `string`. May be a list of comma separated values (e.g. `'127.0.0.1,192.168.1.1/24'` | 
 | namePrefix        | `UNLEASH_NAME_PREFIX`              | undefined        | no       | Used to filter features by using prefix when requesting backend values. | 
 | tags        | `UNLEASH_TAGS`              | undefined        | no       | Used to filter features by using tags set for features. Format should be `tagName:tagValue,tagName2:tagValue2` | 
-| proxySecretHeaderName        | `PROXY_SECRET_HEADER_NAME`              | "authorization"        | no       | Used to specify under which header will be passed proxy secret | 
+| clientKeysHeaderName        | `CLIENT_KEYS_HEADER_NAME`              | "authorization"        | no       | Used to specify under which header will be passed proxy client keys | 
 
 ### Run with Node.js:
 
@@ -144,7 +145,7 @@ const { createApp } = require('@unleash/proxy');
 const app = createApp({
     unleashUrl: 'https://app.unleash-hosted.com/demo/api/',
     unleashApiToken: '56907a2fa53c1d16101d509a10b78e36190b0f918d9f122d',
-    proxySecrets: ['proxy-secret', 'another-proxy-secret', 's1'],
+    clientKeys: ['proxy-secret', 'another-proxy-secret', 's1'],
     refreshInterval: 1000,
     // logLevel: 'info',
     // projectName: 'order-team',

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Keep-Alive: timeout=5
 | -------------   |----------------------     |----------     |:--------:|---------------|
 | unleashUrl      |`UNLEASH_URL`              | n/a           | yes      | API Url to the Unleash instance to connect to |
 | unleashApiToken | `UNLEASH_API_TOKEN`       | n/a           | yes      | API token (client) needed to connect to Unleash API. |
-| clientKeys      | `UNLEASH_CLIENT_KEYS`     | n/a           | yes      | List of proxy secrets the proxy accept. Proxy SDKs needs to set the Proxy secret as the `Authorization` header (or another specified under `clientKeysHeaderName` option) when querying the proxy | 
+| clientKeys      | `UNLEASH_CLIENT_KEYS`     | n/a           | yes      | List of _client keys_ the Unleash proxy accepts. Proxy SDKs needs to set the _client key_ as the `Authorization` header (or another specified under `clientKeysHeaderName` option) when interacting with the Unleash proxy | 
 | proxySecrets    | `UNLEASH_PROXY_SECRETS`   | n/a           | no      | Alias for `clientKeys` in order to keep backward compatibility | 
 | proxyPort       | `PORT`                    | 3000          | no       | The port where the proxy should listen. | 
 | proxyBasePath   | `PROXY_BASE_PATH`         |"/proxy"       | no       | The base path to run the proxy from. Defaults to "/proxy" |

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Keep-Alive: timeout=5
 | trustProxy      | `TRUST_PROXY `            | `false`       | no       | By enabling the trustProxy option, Unleash Proxy will have knowledge that it's sitting behind a proxy and that the X-Forwarded-* header fields may be trusted, which otherwise may be easily spoofed. The proxy will automatically enrich the ip address in the Unleash Context. Can either be `true/false` (Trust all proxies), trust only given IP/CIDR (e.g. `'127.0.0.1'`) as a `string`. May be a list of comma separated values (e.g. `'127.0.0.1,192.168.1.1/24'` | 
 | namePrefix        | `UNLEASH_NAME_PREFIX`              | undefined        | no       | Used to filter features by using prefix when requesting backend values. | 
 | tags        | `UNLEASH_TAGS`              | undefined        | no       | Used to filter features by using tags set for features. Format should be `tagName:tagValue,tagName2:tagValue2` | 
-| clientKeysHeaderName        | `CLIENT_KEYS_HEADER_NAME`              | "authorization"        | no       | Used to specify under which header will be passed proxy client keys | 
+| clientKeysHeaderName        | `CLIENT_KEYS_HEADER_NAME`              | "authorization"        | no       | The name of the HTTP header to use for client keys. Incoming requests must set the value of this header to one of the Proxy's `clientKeys` to be authorized successfully. | 
 
 ### Run with Node.js:
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Keep-Alive: timeout=5
 | unleashUrl      |`UNLEASH_URL`              | n/a           | yes      | API Url to the Unleash instance to connect to |
 | unleashApiToken | `UNLEASH_API_TOKEN`       | n/a           | yes      | API token (client) needed to connect to Unleash API. |
 | clientKeys      | `UNLEASH_CLIENT_KEYS`     | n/a           | yes      | List of _client keys_ the Unleash proxy accepts. Proxy SDKs needs to set the _client key_ as the `Authorization` header (or another specified under `clientKeysHeaderName` option) when interacting with the Unleash proxy | 
-| proxySecrets    | `UNLEASH_PROXY_SECRETS`   | n/a           | no      | Alias for `clientKeys` in order to keep backward compatibility | 
+| proxySecrets    | `UNLEASH_PROXY_SECRETS`   | n/a           | no      | Deprecated alias for `clientKeys`. Please use `clientKeys` instead. | 
 | proxyPort       | `PORT`                    | 3000          | no       | The port where the proxy should listen. | 
 | proxyBasePath   | `PROXY_BASE_PATH`         |"/proxy"       | no       | The base path to run the proxy from. Defaults to "/proxy" |
 | unleashAppName  | `UNLEASH_APP_NAME`        |"unleash-proxy"| no       | App name to used when registering with Unleash |

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Keep-Alive: timeout=5
 | -------------   |----------------------     |----------     |:--------:|---------------|
 | unleashUrl      |`UNLEASH_URL`              | n/a           | yes      | API Url to the Unleash instance to connect to |
 | unleashApiToken | `UNLEASH_API_TOKEN`       | n/a           | yes      | API token (client) needed to connect to Unleash API. |
-| proxySecrets    | `UNLEASH_PROXY_SECRETS`   | n/a           | yes      | List of proxy secrets the proxy accept. Proxy SDKs needs to set the Proxy secret as the `Authorization` heder when querying the proxy | 
+| proxySecrets    | `UNLEASH_PROXY_SECRETS`   | n/a           | yes      | List of proxy secrets the proxy accept. Proxy SDKs needs to set the Proxy secret as the `Authorization` header (or another specified under `proxyHeaderName` option) when querying the proxy | 
 | proxyPort       | `PORT`                    | 3000          | no       | The port where the proxy should listen. | 
 | proxyBasePath   | `PROXY_BASE_PATH`         |"/proxy"       | no       | The base path to run the proxy from. Defaults to "/proxy" |
 | unleashAppName  | `UNLEASH_APP_NAME`        |"unleash-proxy"| no       | App name to used when registering with Unleash |
@@ -122,6 +122,7 @@ Keep-Alive: timeout=5
 | trustProxy      | `TRUST_PROXY `            | `false`       | no       | By enabling the trustProxy option, Unleash Proxy will have knowledge that it's sitting behind a proxy and that the X-Forwarded-* header fields may be trusted, which otherwise may be easily spoofed. The proxy will automatically enrich the ip address in the Unleash Context. Can either be `true/false` (Trust all proxies), trust only given IP/CIDR (e.g. `'127.0.0.1'`) as a `string`. May be a list of comma separated values (e.g. `'127.0.0.1,192.168.1.1/24'` | 
 | namePrefix        | `UNLEASH_NAME_PREFIX`              | undefined        | no       | Used to filter features by using prefix when requesting backend values. | 
 | tags        | `UNLEASH_TAGS`              | undefined        | no       | Used to filter features by using tags set for features. Format should be `tagName:tagValue,tagName2:tagValue2` | 
+| proxyHeaderName        | `PROXY_HEADER_NAME`              | "authorization"        | no       | Used to specify under which header will be passed proxy secret | 
 
 ### Run with Node.js:
 

--- a/example.js
+++ b/example.js
@@ -5,7 +5,7 @@ const { createApp } = require('./dist/app');
 const app = createApp({
     unleashUrl: 'https://app.unleash-hosted.com/demo/api/',
     unleashApiToken: '56907a2fa53c1d16101d509a10b78e36190b0f918d9f122d',
-    proxySecrets: ['proxy-secret', 'another-proxy-secret', 's1'],
+    clientKeys: ['proxy-secret', 'another-proxy-secret', 's1'],
     refreshInterval: 1000,
     // unleashInstanceId: '1337',
     // logLevel: 'info',
@@ -14,5 +14,5 @@ const app = createApp({
 });
 
 app.listen(port, () =>
-  console.log(`Unleash-proxy is listening on port ${port}!`),
+    console.log(`Unleash-proxy is listening on port ${port}!`),
 );

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,7 @@ export interface IProxyOption {
     trustProxy?: boolean | string | number;
     namePrefix?: string;
     tags?: Array<TagFilter>;
+    proxyHeaderName?: string;
 }
 
 export interface IProxyConfig {
@@ -39,6 +40,7 @@ export interface IProxyConfig {
     trustProxy: boolean | string | number;
     namePrefix?: string;
     tags?: Array<TagFilter>;
+    proxyHeaderName: string;
 }
 
 function resolveStringToArray(value?: string): string[] | undefined {
@@ -153,5 +155,9 @@ export function createProxyConfig(option: IProxyOption): IProxyConfig {
         logger: option.logger || new SimpleLogger(logLevel),
         trustProxy,
         tags,
+        proxyHeaderName:
+            option.proxyHeaderName ||
+            process.env.PROXY_HEADER_NAME ||
+            'authorization'
     };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,7 +20,7 @@ export interface IProxyOption {
     trustProxy?: boolean | string | number;
     namePrefix?: string;
     tags?: Array<TagFilter>;
-    proxyHeaderName?: string;
+    proxySecretHeaderName?: string;
 }
 
 export interface IProxyConfig {
@@ -40,7 +40,7 @@ export interface IProxyConfig {
     trustProxy: boolean | string | number;
     namePrefix?: string;
     tags?: Array<TagFilter>;
-    proxyHeaderName: string;
+    proxySecretHeaderName: string;
 }
 
 function resolveStringToArray(value?: string): string[] | undefined {
@@ -155,9 +155,9 @@ export function createProxyConfig(option: IProxyOption): IProxyConfig {
         logger: option.logger || new SimpleLogger(logLevel),
         trustProxy,
         tags,
-        proxyHeaderName:
-            option.proxyHeaderName ||
-            process.env.PROXY_HEADER_NAME ||
+        proxySecretHeaderName:
+            option.proxySecretHeaderName ||
+            process.env.PROXY_SECRET_HEADER_NAME ||
             'authorization'
     };
 }

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -85,15 +85,34 @@ test('should set trust proxy via env var', () => {
 test('should allow options via env', () => {
     process.env.UNLEASH_URL = 'some';
     process.env.UNLEASH_API_TOKEN = 'token';
-    process.env.UNLEASH_PROXY_SECRETS = 's1';
+    process.env.UNLEASH_PROXY_CLIENT_KEYS = 's1';
     process.env.UNLEASH_INSTANCE_ID = 'i1';
     const config = createProxyConfig({});
 
     expect(config.unleashUrl).toBe('some');
     expect(config.unleashApiToken).toBe('token');
-    expect(config.proxySecrets.length).toBe(1);
-    expect(config.proxySecrets[0]).toBe('s1');
+    expect(config.clientKeys.length).toBe(1);
+    expect(config.clientKeys[0]).toBe('s1');
     expect(config.unleashInstanceId).toBe('i1');
+
+    // cleanup
+    delete process.env.UNLEASH_URL;
+    delete process.env.UNLEASH_API_TOKEN;
+    delete process.env.UNLEASH_PROXY_CLIENT_KEYS;
+    delete process.env.UNLEASH_INSTANCE_ID;
+});
+
+test('should allow old "UNLEASH_PROXY_SECRETS" option via env', () => {
+    process.env.UNLEASH_URL = 'some';
+    process.env.UNLEASH_API_TOKEN = 'token';
+    process.env.UNLEASH_PROXY_SECRETS = 's1-token, s2-token';
+    const config = createProxyConfig({});
+
+    expect(config.unleashUrl).toBe('some');
+    expect(config.unleashApiToken).toBe('token');
+    expect(config.clientKeys.length).toBe(2);
+    expect(config.clientKeys[0]).toBe('s1-token');
+    expect(config.clientKeys[1]).toBe('s2-token');
 
     // cleanup
     delete process.env.UNLEASH_URL;
@@ -116,7 +135,7 @@ test('should load custom activation strategy', () => {
     const config = createProxyConfig({
         unleashUrl: 'some',
         unleashApiToken: 'some',
-        proxySecrets: ['s1'],
+        clientKeys: ['s1'],
         customStrategies: [new TestStrat()],
     });
 
@@ -135,7 +154,7 @@ test('should load custom activation strategy from file', () => {
     const config = createProxyConfig({
         unleashUrl: 'some',
         unleashApiToken: 'some',
-        proxySecrets: ['s1'],
+        clientKeys: ['s1'],
     });
 
     expect(config.customStrategies?.length).toBe(1);
@@ -153,7 +172,7 @@ test('should set namePrefix via options', () => {
         unleashUrl: 'some',
         unleashApiToken: 'some',
         namePrefix: 'somePrefix',
-        proxySecrets: ['s1'],
+        clientKeys: ['s1'],
     });
 
     expect(config.namePrefix).toBe('somePrefix');
@@ -164,7 +183,7 @@ test('should set namePrefix via env', () => {
     const config = createProxyConfig({
         unleashUrl: 'some',
         unleashApiToken: 'some',
-        proxySecrets: ['s1'],
+        clientKeys: ['s1'],
     });
 
     expect(config.namePrefix).toBe('prefixViaEnv');
@@ -198,7 +217,7 @@ test('should not set tags with empty env var', () => {
     const config = createProxyConfig({
         unleashUrl: 'some',
         unleashApiToken: 'some',
-        proxySecrets: ['s1'],
+        clientKeys: ['s1'],
     });
 
     expect(config.tags).toBeUndefined();
@@ -210,7 +229,7 @@ test('should set tags with env var', () => {
     const config = createProxyConfig({
         unleashUrl: 'some',
         unleashApiToken: 'some',
-        proxySecrets: ['s1'],
+        clientKeys: ['s1'],
     });
 
     expect(config.tags).toStrictEqual([

--- a/src/test/unleash-proxy.test.ts
+++ b/src/test/unleash-proxy.test.ts
@@ -56,6 +56,37 @@ test('Should return list of toggles', () => {
         });
 });
 
+test('Should return list of toggles with custom proxy secret header', () => {
+    const toggles = [
+        {
+            name: 'test',
+            enabled: true,
+        },
+        {
+            name: 'test2',
+            enabled: true,
+        },
+    ];
+    const client = new MockClient(toggles);
+
+    const proxySecrets = ['sdf'];
+    const app = createApp(
+        { proxySecrets, unleashUrl, unleashApiToken, proxySecretHeaderName: 'NotAuthorized' },
+        client,
+    );
+    client.emit('ready');
+
+    return request(app)
+        .get('/proxy')
+        .set('NotAuthorized', 'sdf')
+        .expect(200)
+        .expect('Content-Type', /json/)
+        .then((response) => {
+            expect(response.body.toggles.length).toEqual(2);
+        });
+});
+
+
 test('Should return list of toggles using env with multiple secrets', () => {
     process.env.UNLEASH_PROXY_SECRETS = 'secret1,secret2';
     const toggles = [

--- a/src/test/unleash-proxy.test.ts
+++ b/src/test/unleash-proxy.test.ts
@@ -71,7 +71,12 @@ test('Should return list of toggles with custom proxy secret header', () => {
 
     const proxySecrets = ['sdf'];
     const app = createApp(
-        { proxySecrets, unleashUrl, unleashApiToken, proxySecretHeaderName: 'NotAuthorized' },
+        {
+            proxySecrets,
+            unleashUrl,
+            unleashApiToken,
+            clientKeysHeaderName: 'NotAuthorized',
+        },
         client,
     );
     client.emit('ready');
@@ -85,7 +90,6 @@ test('Should return list of toggles with custom proxy secret header', () => {
             expect(response.body.toggles.length).toEqual(2);
         });
 });
-
 
 test('Should return list of toggles using env with multiple secrets', () => {
     process.env.UNLEASH_PROXY_SECRETS = 'secret1,secret2';

--- a/src/unleash-proxy.ts
+++ b/src/unleash-proxy.ts
@@ -11,9 +11,9 @@ const NOT_READY =
 export default class UnleashProxy {
     private logger: Logger;
 
-    private proxySecrets: string[];
+    private clientKeys: string[];
 
-    private proxySecretHeaderName: string;
+    private clientKeysHeaderName: string;
 
     private client: IClient;
 
@@ -23,8 +23,8 @@ export default class UnleashProxy {
 
     constructor(client: IClient, config: IProxyConfig) {
         this.logger = config.logger;
-        this.proxySecrets = config.proxySecrets;
-        this.proxySecretHeaderName = config.proxySecretHeaderName;
+        this.clientKeys = config.clientKeys;
+        this.clientKeysHeaderName = config.clientKeysHeaderName;
         this.client = client;
 
         if (client.isReady()) {
@@ -52,16 +52,21 @@ export default class UnleashProxy {
         );
     }
 
-    setProxySecrets(proxySecrets: string[]): void {
-        this.proxySecrets = proxySecrets;
+    // kept for backward compatibility
+    setProxySecrets(clientKeys: string[]): void {
+        this.setClientKeys(clientKeys);
+    }
+
+    setClientKeys(clientKeys: string[]): void {
+        this.clientKeys = clientKeys;
     }
 
     getEnabledToggles(req: Request, res: Response): void {
-        const apiToken = req.header(this.proxySecretHeaderName);
+        const apiToken = req.header(this.clientKeysHeaderName);
 
         if (!this.ready) {
             res.status(503).send(NOT_READY);
-        } else if (!apiToken || !this.proxySecrets.includes(apiToken)) {
+        } else if (!apiToken || !this.clientKeys.includes(apiToken)) {
             res.sendStatus(401);
         } else {
             const { query } = req;
@@ -74,11 +79,11 @@ export default class UnleashProxy {
     }
 
     lookupToggles(req: Request, res: Response): void {
-        const apiToken = req.header(this.proxySecretHeaderName);
+        const apiToken = req.header(this.clientKeysHeaderName);
 
         if (!this.ready) {
             res.status(503).send(NOT_READY);
-        } else if (!apiToken || !this.proxySecrets.includes(apiToken)) {
+        } else if (!apiToken || !this.clientKeys.includes(apiToken)) {
             res.sendStatus(401);
         } else {
             const { context, toggles: toggleNames } = req.body;

--- a/src/unleash-proxy.ts
+++ b/src/unleash-proxy.ts
@@ -13,6 +13,8 @@ export default class UnleashProxy {
 
     private proxySecrets: string[];
 
+    private proxyHeaderName: string;
+
     private client: IClient;
 
     private ready = false;
@@ -22,6 +24,7 @@ export default class UnleashProxy {
     constructor(client: IClient, config: IProxyConfig) {
         this.logger = config.logger;
         this.proxySecrets = config.proxySecrets;
+        this.proxyHeaderName = config.proxyHeaderName;
         this.client = client;
 
         if (client.isReady()) {
@@ -54,7 +57,7 @@ export default class UnleashProxy {
     }
 
     getEnabledToggles(req: Request, res: Response): void {
-        const apiToken = req.header('authorization');
+        const apiToken = req.header(this.proxyHeaderName);
 
         if (!this.ready) {
             res.status(503).send(NOT_READY);
@@ -71,7 +74,7 @@ export default class UnleashProxy {
     }
 
     lookupToggles(req: Request, res: Response): void {
-        const apiToken = req.header('authorization');
+        const apiToken = req.header(this.proxyHeaderName);
 
         if (!this.ready) {
             res.status(503).send(NOT_READY);

--- a/src/unleash-proxy.ts
+++ b/src/unleash-proxy.ts
@@ -13,7 +13,7 @@ export default class UnleashProxy {
 
     private proxySecrets: string[];
 
-    private proxyHeaderName: string;
+    private proxySecretHeaderName: string;
 
     private client: IClient;
 
@@ -24,7 +24,7 @@ export default class UnleashProxy {
     constructor(client: IClient, config: IProxyConfig) {
         this.logger = config.logger;
         this.proxySecrets = config.proxySecrets;
-        this.proxyHeaderName = config.proxyHeaderName;
+        this.proxySecretHeaderName = config.proxySecretHeaderName;
         this.client = client;
 
         if (client.isReady()) {
@@ -57,7 +57,7 @@ export default class UnleashProxy {
     }
 
     getEnabledToggles(req: Request, res: Response): void {
-        const apiToken = req.header(this.proxyHeaderName);
+        const apiToken = req.header(this.proxySecretHeaderName);
 
         if (!this.ready) {
             res.status(503).send(NOT_READY);
@@ -74,7 +74,7 @@ export default class UnleashProxy {
     }
 
     lookupToggles(req: Request, res: Response): void {
-        const apiToken = req.header(this.proxyHeaderName);
+        const apiToken = req.header(this.proxySecretHeaderName);
 
         if (!this.ready) {
             res.status(503).send(NOT_READY);


### PR DESCRIPTION
We have problem with Authorization header cause it's used for our "development gate" for jwt tokens & nginx so we have to provide custom header... I will also prepare PR for UI client sdk to provide that possibility (atm we wrapped fetch to provide custom header...) 

Kind regards
Dziczek