### PR TITLE
docs: fix env variable names so the docs match the implementation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,23 +107,23 @@ Keep-Alive: timeout=5
 | -------------   |----------------------     |----------     |:--------:|---------------|
 | unleashUrl      |`UNLEASH_URL`              | n/a           | yes      | API Url to the Unleash instance to connect to |
 | unleashApiToken | `UNLEASH_API_TOKEN`       | n/a           | yes      | API token (client) needed to connect to Unleash API. |
-| clientKeys      | `UNLEASH_CLIENT_KEYS`     | n/a           | yes      | List of client keys that the proxy should accept. When querying the proxy, Proxy SDKs must set the request's _client keys header_ to one of these values. The default client keys header is `Authorization`. | 
-| proxySecrets    | `UNLEASH_PROXY_SECRETS`   | n/a           | no      | Deprecated alias for `clientKeys`. Please use `clientKeys` instead. | 
-| proxyPort       | `PORT`                    | 3000          | no       | The port where the proxy should listen. | 
+| clientKeys      | `UNLEASH_PROXY_CLIENT_KEYS`     | n/a           | yes      | List of client keys that the proxy should accept. When querying the proxy, Proxy SDKs must set the request's _client keys header_ to one of these values. The default client keys header is `Authorization`. |
+| proxySecrets    | `UNLEASH_PROXY_SECRETS`   | n/a           | no      | Deprecated alias for `clientKeys`. Please use `clientKeys` instead. |
+| proxyPort       | `PORT`                    | 3000          | no       | The port where the proxy should listen. |
 | proxyBasePath   | `PROXY_BASE_PATH`         |"/proxy"       | no       | The base path to run the proxy from. Defaults to "/proxy" |
 | unleashAppName  | `UNLEASH_APP_NAME`        |"unleash-proxy"| no       | App name to used when registering with Unleash |
 | unleashInstanceId | `UNLEASH_INSTANCE_ID`        | `generated` | no       | Unleash instance id to used when registering with Unleash |
-| refreshInterval | `UNLEASH_FETCH_INTERVAL`  | 5000          | no       | How often the proxy should query Unleash for updates, defined in ms. | 
-| metricsInterval | `UNLEASH_METRICS_INTERVAL`| 30000         | no       | How often the proxy should send usage metrics back to Unleash, defined in ms. | 
-| environment     | `UNLEASH_ENVIRONMENT`     | `undefined`   | no       | If set this will be the `environment` used by the proxy in the Unleash Context. It will not be possible for proxy SDKs to override the environment if set. | 
-| projectName     | `UNLEASH_PROJECT_NAME`    | `undefined`   | no       | The projectName (id) to fetch feature toggles for. The proxy will only return know about feature toggles that belongs to the project, if specified.  | | 
-| logger          | n/a                       | SimpleLogger  | no       | Register a custom logger. | 
-| logLevel        | `LOG_LEVEL `              | "warn"        | no       | Used to set logLevel. Supported options: "debug", "info", "warn", "error" and "fatal" | 
-| customStrategies| `UNLEASH_CUSTOM_STRATEGIES_FILE` | []	  | no		 | Use this option to inject implementation of custom activation strategies. If you are using `UNLEASH_CUSTOM_STRATEGIES_FILE` you need to provide a valid path to a javascript files which exports an array of custom activation strategies and the SDK will automatically load these | 
-| trustProxy      | `TRUST_PROXY `            | `false`       | no       | By enabling the trustProxy option, Unleash Proxy will have knowledge that it's sitting behind a proxy and that the X-Forwarded-* header fields may be trusted, which otherwise may be easily spoofed. The proxy will automatically enrich the ip address in the Unleash Context. Can either be `true/false` (Trust all proxies), trust only given IP/CIDR (e.g. `'127.0.0.1'`) as a `string`. May be a list of comma separated values (e.g. `'127.0.0.1,192.168.1.1/24'` | 
-| namePrefix        | `UNLEASH_NAME_PREFIX`              | undefined        | no       | Used to filter features by using prefix when requesting backend values. | 
-| tags        | `UNLEASH_TAGS`              | undefined        | no       | Used to filter features by using tags set for features. Format should be `tagName:tagValue,tagName2:tagValue2` | 
-| clientKeysHeaderName        | `CLIENT_KEYS_HEADER_NAME`              | "authorization"        | no       | The name of the HTTP header to use for client keys. Incoming requests must set the value of this header to one of the Proxy's `clientKeys` to be authorized successfully. | 
+| refreshInterval | `UNLEASH_FETCH_INTERVAL`  | 5000          | no       | How often the proxy should query Unleash for updates, defined in ms. |
+| metricsInterval | `UNLEASH_METRICS_INTERVAL`| 30000         | no       | How often the proxy should send usage metrics back to Unleash, defined in ms. |
+| environment     | `UNLEASH_ENVIRONMENT`     | `undefined`   | no       | If set this will be the `environment` used by the proxy in the Unleash Context. It will not be possible for proxy SDKs to override the environment if set. |
+| projectName     | `UNLEASH_PROJECT_NAME`    | `undefined`   | no       | The projectName (id) to fetch feature toggles for. The proxy will only return know about feature toggles that belongs to the project, if specified.  | |
+| logger          | n/a                       | SimpleLogger  | no       | Register a custom logger. |
+| logLevel        | `LOG_LEVEL `              | "warn"        | no       | Used to set logLevel. Supported options: "debug", "info", "warn", "error" and "fatal" |
+| customStrategies| `UNLEASH_CUSTOM_STRATEGIES_FILE` | []	  | no		 | Use this option to inject implementation of custom activation strategies. If you are using `UNLEASH_CUSTOM_STRATEGIES_FILE` you need to provide a valid path to a javascript files which exports an array of custom activation strategies and the SDK will automatically load these |
+| trustProxy      | `TRUST_PROXY `            | `false`       | no       | By enabling the trustProxy option, Unleash Proxy will have knowledge that it's sitting behind a proxy and that the X-Forwarded-* header fields may be trusted, which otherwise may be easily spoofed. The proxy will automatically enrich the ip address in the Unleash Context. Can either be `true/false` (Trust all proxies), trust only given IP/CIDR (e.g. `'127.0.0.1'`) as a `string`. May be a list of comma separated values (e.g. `'127.0.0.1,192.168.1.1/24'` |
+| namePrefix        | `UNLEASH_NAME_PREFIX`              | undefined        | no       | Used to filter features by using prefix when requesting backend values. |
+| tags        | `UNLEASH_TAGS`              | undefined        | no       | Used to filter features by using tags set for features. Format should be `tagName:tagValue,tagName2:tagValue2` |
+| clientKeysHeaderName        | `CLIENT_KEY_HEADER_NAME`              | "authorization"        | no       | The name of the HTTP header to use for client keys. Incoming requests must set the value of this header to one of the Proxy's `clientKeys` to be authorized successfully. |
 
 ### Run with Node.js:
 


### PR DESCRIPTION
As was mentioned in the community Slack, these two env variables are not correct in the documentation. I'm not sure which version is intentional, but with the current version of the proxy, these are the values that it looks for.