### PR TITLE
feat: experimental support for bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,17 @@ Keep-Alive: timeout=5
 | tags        | `UNLEASH_TAGS`              | undefined        | no       | Used to filter features by using tags set for features. Format should be `tagName:tagValue,tagName2:tagValue2` |
 | clientKeysHeaderName        | `CLIENT_KEY_HEADER_NAME`              | "authorization"        | no       | The name of the HTTP header to use for client keys. Incoming requests must set the value of this header to one of the Proxy's `clientKeys` to be authorized successfully. |
 
+
+### Experimental options
+
+Some functionality is under validation and introduced as experimental, to allow us to test new functionality early. You should expect these to change in any future feature release. 
+
+| Option          | Environment Variable      | Default value | Required |  Description  |
+| -------------   |----------------------     |----------     |:--------:|---------------|
+| expBootstrap    | n/a                       | n/a           | no      | Where the Proxy can bootstrap configuration from. See [Node.js SDK](https://github.com/Unleash/unleash-client-node#bootstrap) for details. |
+| expBootstrap.url    | `EXP_BOOTSTRAP_URL`   | n/a           | no      | Url where the Proxy can bootstrap configuration from. See [Node.js SDK](https://github.com/Unleash/unleash-client-node#bootstrap) for details. |
+| expBootstrap.urlHeaders.Authorization    | `EXP_BOOTSTRAP_AUTHORIZATION`   | n/a           | no      | Authorization header value to be used when bootstrapping |
+| expServerSideSdkConfig.tokens    | `EXP_SERVER_SIDE_SDK_CONFIG_TOKENS`                       | n/a           | no      | API tokens that can be used by Server SDKs (and proxies) to read feature toggle configuration from this Proxy instance. |
 ### Run with Node.js:
 
 **STEP 1: Install dependency**

--- a/example.js
+++ b/example.js
@@ -3,17 +3,20 @@ const port = process.env.PORT || 3000;
 const { createApp } = require('./dist/app');
 
 const app = createApp({
-    unleashUrl: 'https://app.unleash-hosted.com/demo/api/',
+    unleashUrl: 'https://app2.unleash-hosted.com/demo/api/',
     unleashApiToken: '56907a2fa53c1d16101d509a10b78e36190b0f918d9f122d',
     clientKeys: ['proxy-secret', 'another-proxy-secret', 's1'],
     refreshInterval: 1000,
-    bootstrapTokens: ['bootstrap-token'],
-    bootstrap: {
-        url: 'https://localhost:4000',
+    logLevel: 'trace',
+    expBootstrapTokens: ['bootstrap-token'],
+    /*
+    expBootstrap: {
+        url: 'https://localhost:4001',
         urlHeaders: {
-            Authorization: 'some-token',
+            Authorization: 'bootstrap-token',
         },
     },
+    */
     // unleashInstanceId: '1337',
     // logLevel: 'info',
     // projectName: 'order-team', // optional

--- a/example.js
+++ b/example.js
@@ -3,7 +3,7 @@ const port = process.env.PORT || 3000;
 const { createApp } = require('./dist/app');
 
 const app = createApp({
-    unleashUrl: 'https://app2.unleash-hosted.com/demo/api/',
+    unleashUrl: 'https://app.unleash-hosted.com/demo/api/',
     unleashApiToken: '56907a2fa53c1d16101d509a10b78e36190b0f918d9f122d',
     clientKeys: ['proxy-secret', 'another-proxy-secret', 's1'],
     refreshInterval: 1000,

--- a/example.js
+++ b/example.js
@@ -9,14 +9,12 @@ const app = createApp({
     refreshInterval: 1000,
     logLevel: 'trace',
     expBootstrapTokens: ['bootstrap-token'],
-    /*
     expBootstrap: {
-        url: 'https://localhost:4001',
+        url: 'https://localhost:4000',
         urlHeaders: {
             Authorization: 'bootstrap-token',
         },
     },
-    */
     // unleashInstanceId: '1337',
     // logLevel: 'info',
     // projectName: 'order-team', // optional

--- a/example.js
+++ b/example.js
@@ -8,7 +8,9 @@ const app = createApp({
     clientKeys: ['proxy-secret', 'another-proxy-secret', 's1'],
     refreshInterval: 1000,
     logLevel: 'trace',
-    expBootstrapTokens: ['bootstrap-token'],
+    expServerSideSdkConfig: {
+        tokens: ['server-sdk-token-1'],
+    },
     expBootstrap: {
         url: 'https://localhost:4000',
         urlHeaders: {

--- a/example.js
+++ b/example.js
@@ -7,6 +7,13 @@ const app = createApp({
     unleashApiToken: '56907a2fa53c1d16101d509a10b78e36190b0f918d9f122d',
     clientKeys: ['proxy-secret', 'another-proxy-secret', 's1'],
     refreshInterval: 1000,
+    bootstrapTokens: ['bootstrap-token'],
+    bootstrap: {
+        url: 'https://localhost:4000',
+        urlHeaders: {
+            Authorization: 'some-token',
+        },
+    },
     // unleashInstanceId: '1337',
     // logLevel: 'info',
     // projectName: 'order-team', // optional

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,6 @@
 import EventEmitter from 'events';
 import { Context, initialize, Unleash, Variant } from 'unleash-client';
+import { FeatureInterface } from 'unleash-client/lib/feature';
 import Metrics from 'unleash-client/lib/metrics';
 import { defaultStrategies } from 'unleash-client/lib/strategy';
 import { IProxyConfig } from './config';
@@ -35,6 +36,7 @@ export interface IClient extends EventEmitter {
         toggleNames: string[],
         context: Context,
     ) => FeatureToggleStatus[];
+    getFeatureToggleDefinitions(): FeatureInterface[];
     registerMetrics(metrics: any): void;
     isReady(): boolean;
 }
@@ -75,6 +77,7 @@ class Client extends EventEmitter implements IClient {
             namePrefix: config.namePrefix,
             tags: config.tags,
             customHeadersFunction,
+            bootstrap: config.bootstrap,
         });
 
         // Custom metrics Instance
@@ -142,6 +145,10 @@ class Client extends EventEmitter implements IClient {
                 impressionData: definition.impressionData,
             };
         });
+    }
+
+    getFeatureToggleDefinitions(): FeatureInterface[] {
+        return this.unleash.getFeatureToggleDefinitions();
     }
 
     /*

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import { Strategy, TagFilter } from 'unleash-client';
+import { BootstrapOptions } from 'unleash-client/lib/repository/bootstrap-provider';
 import { Logger, LogLevel, SimpleLogger } from './logger';
 import { generateInstanceId } from './util';
 
@@ -22,6 +23,8 @@ export interface IProxyOption {
     namePrefix?: string;
     tags?: Array<TagFilter>;
     clientKeysHeaderName?: string;
+    bootstrapTokens?: string[]; // experimental
+    bootstrap?: BootstrapOptions; // experimental
 }
 
 export interface IProxyConfig {
@@ -42,6 +45,8 @@ export interface IProxyConfig {
     namePrefix?: string;
     tags?: Array<TagFilter>;
     clientKeysHeaderName: string;
+    bootstrapTokens: string[];
+    bootstrap?: BootstrapOptions;
 }
 
 function resolveStringToArray(value?: string): string[] | undefined {
@@ -167,5 +172,7 @@ export function createProxyConfig(option: IProxyOption): IProxyConfig {
             option.clientKeysHeaderName ||
             process.env.CLIENT_KEY_HEADER_NAME ||
             'authorization',
+        bootstrapTokens: option.bootstrapTokens || [],
+        bootstrap: option.bootstrap,
     };
 }

--- a/src/test/client.mock.ts
+++ b/src/test/client.mock.ts
@@ -1,5 +1,6 @@
 import EventEmitter from 'events';
 import { Context } from 'unleash-client';
+import { FeatureInterface } from 'unleash-client/lib/feature';
 import { FeatureToggleStatus, IClient } from '../client';
 
 class MockClient extends EventEmitter implements IClient {
@@ -15,6 +16,10 @@ class MockClient extends EventEmitter implements IClient {
         super();
         this.toggles = toggles;
         this.apiToken = 'default';
+    }
+
+    getFeatureToggleDefinitions(): FeatureInterface[] {
+        throw new Error('Method not implemented.');
     }
 
     isReady(): boolean {

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -238,3 +238,35 @@ test('should set tags with env var', () => {
     ]);
     delete process.env.UNLEASH_CUSTOM_STRATEGIES_FILE;
 });
+
+test('should read serverSideSdkConfig from env vars', () => {
+    process.env.EXP_SERVER_SIDE_SDK_CONFIG_TOKENS = 'super1, super2';
+    const config = createProxyConfig({
+        unleashUrl: 'some',
+        unleashApiToken: 'some',
+        clientKeys: ['s1'],
+    });
+
+    expect(config.serverSideSdkConfig?.tokens).toStrictEqual([
+        'super1',
+        'super2',
+    ]);
+    delete process.env.EXP_SERVER_SIDE_SDK_CONFIG_TOKENS;
+});
+
+test('should read bootstrap from env vars', () => {
+    process.env.EXP_BOOTSTRAP_URL = 'https://boostrap.unleash.run';
+    process.env.EXP_BOOTSTRAP_AUTHORIZATION = 'AUTH-BOOTSTRAP';
+    const config = createProxyConfig({
+        unleashUrl: 'some',
+        unleashApiToken: 'some',
+        clientKeys: ['s1'],
+    });
+
+    expect(config.bootstrap).toStrictEqual({
+        url: 'https://boostrap.unleash.run',
+        urlHeaders: { Authorization: 'AUTH-BOOTSTRAP' },
+    });
+    delete process.env.EXP_BOOTSTRAP_URL;
+    delete process.env.EXP_BOOTSTRAP_AUTHORIZATION;
+});

--- a/src/unleash-proxy.ts
+++ b/src/unleash-proxy.ts
@@ -13,7 +13,7 @@ export default class UnleashProxy {
 
     private clientKeys: string[];
 
-    private bootstrapTokens: string[];
+    private serverSideTokens: string[];
 
     private clientKeysHeaderName: string;
 
@@ -26,7 +26,9 @@ export default class UnleashProxy {
     constructor(client: IClient, config: IProxyConfig) {
         this.logger = config.logger;
         this.clientKeys = config.clientKeys;
-        this.bootstrapTokens = config.bootstrapTokens;
+        this.serverSideTokens = config.serverSideSdkConfig
+            ? config.serverSideSdkConfig.tokens
+            : [];
         this.clientKeysHeaderName = config.clientKeysHeaderName;
         this.client = client;
 
@@ -46,7 +48,7 @@ export default class UnleashProxy {
         router.get('/', this.getEnabledToggles.bind(this));
         router.post('/', this.lookupToggles.bind(this));
         router.post('/client/metrics', this.registerMetrics.bind(this));
-        router.get('/client/features', this.bootstrap.bind(this));
+        router.get('/client/features', this.unleashApi.bind(this));
     }
 
     private setReady() {
@@ -83,11 +85,11 @@ export default class UnleashProxy {
     }
 
     lookupToggles(req: Request, res: Response): void {
-        const apiToken = req.header(this.clientKeysHeaderName);
+        const clientToken = req.header(this.clientKeysHeaderName);
 
         if (!this.ready) {
             res.status(503).send(NOT_READY);
-        } else if (!apiToken || !this.clientKeys.includes(apiToken)) {
+        } else if (!clientToken || !this.clientKeys.includes(clientToken)) {
             res.sendStatus(401);
         } else {
             const { context, toggles: toggleNames = [] } = req.body;
@@ -120,11 +122,11 @@ export default class UnleashProxy {
         res.sendStatus(200);
     }
 
-    bootstrap(req: Request, res: Response): void {
+    unleashApi(req: Request, res: Response): void {
         const apiToken = req.header(this.clientKeysHeaderName);
         if (!this.ready) {
             res.status(503).send(NOT_READY);
-        } else if (apiToken && this.bootstrapTokens.includes(apiToken)) {
+        } else if (apiToken && this.serverSideTokens.includes(apiToken)) {
             const features = this.client.getFeatureToggleDefinitions();
             res.set('Cache-control', 'public, max-age=2');
             res.send({ version: 2, features });


### PR DESCRIPTION
Add support for the bootstrap feature, introduced in the Node.js SDK v3.11

For clarity we try to cover two use cases:

**1. Allow the Unleash-Proxy to bootstrap from "somewhere"** 
   - Could be another Unleash-Proxy instance, a S3 bucket, or wherever you have a fresh feature-toggle-configuration state stored.
   - expBootstrap.url - where the proxy should bootstrap from. Can also be set via `EXP_BOOTSTRAP_URL`
   - expBootstrap.urlHeaders - headers to be added to the request. Typically the Authorization header.

**2. Allow any server-side SDK to bootstrap from the the Unleash Proxy.**
   - The SDKs should connect to the built in "bootstrap url" and provide a `expBoostrapTokens`. These tokens needs to be different than the `clientKeys`, as the bootstrap data will be the full local cache of all feature toggle configuration.

PS! I am really unsure on the naming of things.