### PR TITLE
Allow paths other than /proxy or /something/proxy

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -28,7 +28,7 @@ export function createApp(
     app.use(compression());
 
     app.use(
-        `${config.proxyBasePath}/proxy`,
+        config.proxyBasePath,
         cors(corsOptions),
         express.json(),
         proxy.middleware,

--- a/src/config.ts
+++ b/src/config.ts
@@ -149,7 +149,7 @@ export function createProxyConfig(option: IProxyOption): IProxyConfig {
         customStrategies,
         clientKeys,
         proxyBasePath:
-            option.proxyBasePath || process.env.PROXY_BASE_PATH || '',
+            option.proxyBasePath || process.env.PROXY_BASE_PATH || '/proxy',
         refreshInterval:
             option.refreshInterval ||
             safeNumber(process.env.UNLEASH_FETCH_INTERVAL, 5_000),


### PR DESCRIPTION
Hey!
We have Unleash proxy in a separate domain and we want to serve requests from the root path.
This PR is to allow the tool to be configured this way.
Thanks