### PR TITLE
feat: generate type output to publish them to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.6.1",
   "description": "The Unleash Proxy (Open-Source)",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc --pretty",
     "example": "npm run build && node example",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     // "allowJs": true,                             /* Allow javascript files to be compiled. */
     // "checkJs": true,                             /* Report errors in .js files. */
     // "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
-    // "declaration": true,                         /* Generates corresponding '.d.ts' file. */
+    "declaration": true,                            /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
     "sourceMap": true,                              /* Generates corresponding '.map' file. */
     // "outFile": "./",                             /* Concatenate and emit output to single file. */


### PR DESCRIPTION
This PR outputs types to the `/dist` folder to be able to publish them to the NPM-Registry.

```
...
npm notice 202B   dist/index.d.ts                             
npm notice 889B   dist/index.js                               
npm notice 250B   dist/index.js.map                           
npm notice 786B   dist/logger.d.ts                            
npm notice 2.0kB  dist/logger.js                              
npm notice 2.0kB  dist/logger.js.map                          
npm notice 145B   dist/metrics-schema.d.ts                    
npm notice 1.2kB  dist/metrics-schema.js                      
npm notice 1.1kB  dist/metrics-schema.js.map 
...
```

Closes #53 

Note:
- The types will also be added to the Docker-Image. This is not problematic as they will be ignored by `node` on execution
- The unpacked size of the NPM package increases from 163 kB to 166kB