### PR TITLE
Fix loading of custom strategies when using Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,10 @@ COPY --from=builder /unleash-proxy /unleash-proxy
 
 RUN rm -rf /usr/local/lib/node_modules/npm/
 
+RUN chown -R node:node /unleash-proxy
+
 EXPOSE 4242
 
 USER node
 
-CMD node dist/start
+CMD ./server.sh

--- a/server.sh
+++ b/server.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+set -e
+
+if [ ! -z "$UNLEASH_CUSTOM_STRATEGIES_FILE" ]; then
+	echo "Loading custom strategies from file $UNLEASH_CUSTOM_STRATEGIES_FILE"
+	mkdir -p ./dist/strategies
+	cp $UNLEASH_CUSTOM_STRATEGIES_FILE ./dist/strategies
+	export UNLEASH_CUSTOM_STRATEGIES_FILE="./strategies/$(basename $UNLEASH_CUSTOM_STRATEGIES_FILE)"
+fi
+
+node dist/start


### PR DESCRIPTION
  This commits adds a `server.sh` script that will, when
  `UNLEASH_CUSTOM_STRATEGIES_FILE` is set, copy the file into
  `./dist/strategies` and use that location when loading the
  strategy. This removes the need to "re-bundle" `unleash-client`,
  as mentioned in #29.