### PR TITLE
chore: Specify that the proxy requires Node 14 or newer

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git+https://github.com/Unleash/unleash-proxy.git"
   },
+  "engines": {
+    "node": ">=14"
+  },
   "keywords": [
     "Unleash",
     "frontend",


### PR DESCRIPTION
This PR adds an `engine` property to the package.json, specifying that the Proxy requires Node 14 or higher to run.

closes #63.