### PR TITLE
feat: add tini as a init wrapper for node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ RUN rm -rf /usr/local/lib/node_modules/npm/
 
 RUN chown -R node:node /unleash-proxy
 
+RUN apk add --no-cache tini
+ENTRYPOINT ["/sbin/tini", "--"]
+
 EXPOSE 4242
 
 USER node


### PR DESCRIPTION
TL;DR: Adding `Tini` as init wrapper.

## About the changes
As per [docker-node documentation](https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#handling-kernel-signals), Node.js was not designed to run as PID 1 and to handle SIGINT they recommend using `Tini`. This will allow people to use Kubernetes to proper trigger shutdowns on old deployments.

<!-- Does it close an issue? Multiple? -->
Closes # .
