### PR TITLE
chore: upgrade unleash client to 3.14.1 for segments and fix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "express": "^4.18.1",
     "json-schema-to-ts": "^2.3.0",
     "openapi-types": "^11.0.0",
-    "unleash-client": "^3.13.4"
+    "unleash-client": "^3.14.1"
   },
   "devDependencies": {
     "@babel/core": "^7.17.10",

--- a/src/test/client.test.ts
+++ b/src/test/client.test.ts
@@ -28,6 +28,7 @@ test('should add environment to isEnabled calls', () => {
     fakeUnleash.toggleDefinitions.push({
         name: 'test',
         enabled: false,
+        type: 'experiment',
         stale: false,
         strategies: [],
         variants: [],
@@ -64,6 +65,7 @@ test('should override environment to isEnabled calls', () => {
     fakeUnleash.toggleDefinitions.push({
         name: 'test',
         enabled: false,
+        type: 'experiment',
         stale: false,
         strategies: [],
         variants: [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -4512,10 +4512,10 @@ unique-slug@^2.0.0:
   dependencies:
     imurmurhash "^0.1.4"
 
-unleash-client@^3.13.4:
-  version "3.13.4"
-  resolved "https://registry.yarnpkg.com/unleash-client/-/unleash-client-3.13.4.tgz#e23da40ea3545b08e365417cde7bc09884a9154a"
-  integrity sha512-zpKgxR0u7mRFjcNA493wqcXfdj+jGSnDahh/PFfM3lR9RKeyrq34mGp2zfkGngrbvHwn8rd43ygfWRXcOc+ofA==
+unleash-client@^3.14.1:
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/unleash-client/-/unleash-client-3.14.1.tgz#17ed6ba1107604e4067bee9e041c9ebfec600701"
+  integrity sha512-kNVnra8M0WtA/fYUyDTwNaUdV8vnPIejigxzCYfeDGKCYvfMaUwJnlwu4HDxefeQWT/EI4ZZ1Boxv4HZy5Ra6A==
   dependencies:
     ip "^1.1.5"
     make-fetch-happen "^9.0.4"


### PR DESCRIPTION
Upgrades the unleash client to 3.14.1 so global segments can be used and fixes some test data due to changing data types on unleash client