### PR TITLE
meta: add stale bot config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,1 @@
+_extends: .github


### PR DESCRIPTION
This change adds a stale bot config that points to the org-wide config introduced in https://github.com/Unleash/.github/pull/14