### PR TITLE
Add Prometheus endpoint

### DIFF
--- a/src/openapi/spec/prometheus-request-response.ts
+++ b/src/openapi/spec/prometheus-request-response.ts
@@ -1,7 +1,8 @@
 import { OpenAPIV3 } from 'openapi-types';
 
 export const prometheusRequestResponse: OpenAPIV3.ResponseObject = {
-    description: 'The request was successful. Response in plain text format conforming to Prometheus exposition format',
+    description:
+        'The request was successful. Response in plain text format conforming to Prometheus exposition format',
     content: {
         'text/plain': {
             schema: {

--- a/src/openapi/spec/prometheus-request-response.ts
+++ b/src/openapi/spec/prometheus-request-response.ts
@@ -1,0 +1,13 @@
+import { OpenAPIV3 } from 'openapi-types';
+
+export const prometheusRequestResponse: OpenAPIV3.ResponseObject = {
+    description: 'The request was successful. Response in plain text format conforming to Prometheus exposition format',
+    content: {
+        'text/plain': {
+            schema: {
+                type: 'string',
+                example: 'metric_name 1',
+            },
+        },
+    },
+} as const;

--- a/src/test/__snapshots__/openapi.test.ts.snap
+++ b/src/test/__snapshots__/openapi.test.ts.snap
@@ -754,7 +754,7 @@ Object {
         ],
       },
     },
-    "/proxy/prometheus": Object {
+    "/proxy/internal-backstage/prometheus": Object {
       "get": Object {
         "description": "Returns a 200 and valid Prometheus text syntax if the proxy is ready to receive requests. Otherwise returns a 503 NOT READY.",
         "responses": Object {

--- a/src/test/__snapshots__/openapi.test.ts.snap
+++ b/src/test/__snapshots__/openapi.test.ts.snap
@@ -754,6 +754,40 @@ Object {
         ],
       },
     },
+    "/proxy/prometheus": Object {
+      "get": Object {
+        "description": "Returns a 200 and valid Prometheus text syntax if the proxy is ready to receive requests. Otherwise returns a 503 NOT READY.",
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "example": "metric_name 1",
+                  "type": "string",
+                },
+              },
+            },
+            "description": "The request was successful. Response in plain text format conforming to Prometheus exposition format",
+          },
+          "503": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "example": "The Unleash Proxy has not connected to the Unleash API and is not ready to accept requests yet.",
+                  "type": "string",
+                },
+              },
+            },
+            "description": "The proxy isn't ready to accept requests yet.",
+          },
+        },
+        "security": Array [],
+        "summary": "Check whether the proxy is up and running",
+        "tags": Array [
+          "Operational",
+        ],
+      },
+    },
   },
   "security": Array [
     Object {

--- a/src/unleash-proxy.ts
+++ b/src/unleash-proxy.ts
@@ -154,7 +154,7 @@ export default class UnleashProxy {
         );
 
         router.get(
-            '/prometheus',
+            '/internal-backstage/prometheus',
             openApiService.validPath({
                 security: [],
                 responses: {

--- a/src/unleash-proxy.ts
+++ b/src/unleash-proxy.ts
@@ -7,6 +7,7 @@ import { OpenApiService } from './openapi/openapi-service';
 import { featuresResponse } from './openapi/spec/features-response';
 import { NOT_READY_MSG, standardResponses } from './openapi/common-responses';
 import { apiRequestResponse } from './openapi/spec/api-request-response';
+import { prometheusRequestResponse } from './openapi/spec/prometheus-request-response';
 import { ApiRequestSchema } from './openapi/spec/api-request-schema';
 import { FeaturesSchema } from './openapi/spec/features-schema';
 import { lookupTogglesRequest } from './openapi/spec/lookup-toggles-request';
@@ -151,6 +152,23 @@ export default class UnleashProxy {
             }),
             this.health.bind(this),
         );
+
+        router.get(
+            '/prometheus',
+            openApiService.validPath({
+                security: [],
+                responses: {
+                    ...standardResponses(503),
+                    200: prometheusRequestResponse,
+                },
+                description:
+                    'Returns a 200 and valid Prometheus text syntax if the proxy is ready to receive requests. Otherwise returns a 503 NOT READY.',
+                summary:
+                    'Check whether the proxy is up and running',
+                tags: ['Operational'],
+            }),
+            this.prometheus.bind(this),
+        );
     }
 
     private setReady() {
@@ -209,6 +227,18 @@ export default class UnleashProxy {
             res.status(503).send(NOT_READY_MSG);
         } else {
             res.send('ok');
+        }
+    }
+
+    prometheus(_: Request, res: Response<string>): void {
+        if (!this.ready) {
+            res.status(503).send(NOT_READY_MSG);
+        } else {
+            const prometheusResponse = '# HELP unleash_proxy_up Indication that the service is up. \n'
+              + '# TYPE unleash_proxy_up counter\n'
+              + 'unleash_proxy_up 1\n';
+            res.set('Content-type', 'text/plain');
+            res.send(prometheusResponse);
         }
     }
 

--- a/src/unleash-proxy.ts
+++ b/src/unleash-proxy.ts
@@ -163,8 +163,7 @@ export default class UnleashProxy {
                 },
                 description:
                     'Returns a 200 and valid Prometheus text syntax if the proxy is ready to receive requests. Otherwise returns a 503 NOT READY.',
-                summary:
-                    'Check whether the proxy is up and running',
+                summary: 'Check whether the proxy is up and running',
                 tags: ['Operational'],
             }),
             this.prometheus.bind(this),
@@ -234,9 +233,10 @@ export default class UnleashProxy {
         if (!this.ready) {
             res.status(503).send(NOT_READY_MSG);
         } else {
-            const prometheusResponse = '# HELP unleash_proxy_up Indication that the service is up. \n'
-              + '# TYPE unleash_proxy_up counter\n'
-              + 'unleash_proxy_up 1\n';
+            const prometheusResponse =
+                '# HELP unleash_proxy_up Indication that the service is up. \n' +
+                '# TYPE unleash_proxy_up counter\n' +
+                'unleash_proxy_up 1\n';
             res.set('Content-type', 'text/plain');
             res.send(prometheusResponse);
         }


### PR DESCRIPTION
Responding in a Prometheus exposition format
https://prometheus.io/docs/instrumenting/exposition_formats/

<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

To be able to monitor if the unleash-proxy is up and running from Prometheus we need an endpoint that we can scrape i.e. responds in a format conforming to Prometheus exposition format.

<!-- Does it close an issue? Multiple? -->
Closes # .

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->

This simple solution will suffice for us. Hopefully it can be built on further if you want more metrics.
I did not expose any other internal metrics. Did not know your policy on that or if you would like to use any other library for that in that case.