### PR TITLE
fix: OpenAPI POST /features payload is wrong

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "jest",
     "updateSnapshots": "jest -u",
     "prepare": "npm run build",
-    "dev": "ts-node-dev src/start.ts",
+    "dev": "ENABLE_OAS=true ts-node-dev src/start.ts",
     "fmt": "prettier src --write --loglevel warn",
     "fmt:check": "prettier src --check"
   },

--- a/src/app.ts
+++ b/src/app.ts
@@ -21,8 +21,6 @@ export function createApp(
         openApiService.useDocs(app);
     }
 
-    openApiService.useErrorHandler(app);
-
     const proxy = new UnleashProxy(client, config, openApiService);
 
     app.disable('x-powered-by');

--- a/src/client.ts
+++ b/src/client.ts
@@ -148,7 +148,7 @@ class Client extends EventEmitter implements IClient {
                 name,
                 enabled,
                 variant: this.unleash.getVariant(name, context),
-                impressionData: definition.impressionData,
+                impressionData: definition?.impressionData ?? false,
             };
         });
     }

--- a/src/openapi/common-responses.ts
+++ b/src/openapi/common-responses.ts
@@ -19,6 +19,40 @@ export const unauthorizedResponse = {
     description: 'Authorization information is missing or invalid.',
 } as const;
 
+export const badRequestResponse = {
+    description: 'The provided request data is invalid.',
+    content: {
+        'application/json': {
+            schema: {
+                type: 'object',
+                required: ['error'],
+                properties: {
+                    error: { type: 'string' },
+                    validation: {
+                        type: 'array',
+                        items: { type: 'object' },
+                    },
+                },
+                example: {
+                    error: 'Request validation failed',
+                    validation: [
+                        {
+                            keyword: 'required',
+                            dataPath: '.body',
+                            schemaPath:
+                                '#/components/schemas/registerMetricsSchema/required',
+                            params: {
+                                missingProperty: 'appName',
+                            },
+                            message: "should have required property 'appName'",
+                        },
+                    ],
+                },
+            },
+        },
+    },
+} as const;
+
 export const emptySuccessResponse = {
     description: 'The request was successful.',
     content: {
@@ -33,6 +67,7 @@ export const emptySuccessResponse = {
 
 const commonResponses = {
     200: emptySuccessResponse,
+    400: badRequestResponse,
     401: unauthorizedResponse,
     503: notReadyResponse,
 } as const;

--- a/src/openapi/common-responses.ts
+++ b/src/openapi/common-responses.ts
@@ -3,7 +3,7 @@ import { OpenAPIV3 } from 'openapi-types';
 export const NOT_READY_MSG =
     'The Unleash Proxy has not connected to the Unleash API and is not ready to accept requests yet.';
 
-export const notReadyResponse: OpenAPIV3.ResponseObject = {
+export const notReadyResponse = {
     description: "The proxy isn't ready to accept requests yet.",
     content: {
         'text/plain': {
@@ -15,11 +15,11 @@ export const notReadyResponse: OpenAPIV3.ResponseObject = {
     },
 } as const;
 
-export const unauthorizedResponse: OpenAPIV3.ResponseObject = {
+export const unauthorizedResponse = {
     description: 'Authorization information is missing or invalid.',
 } as const;
 
-export const emptySuccessResponse: OpenAPIV3.ResponseObject = {
+export const emptySuccessResponse = {
     description: 'The request was successful.',
     content: {
         'text/plain': {
@@ -31,21 +31,21 @@ export const emptySuccessResponse: OpenAPIV3.ResponseObject = {
     },
 } as const;
 
-const commonResponses: Record<string, OpenAPIV3.ResponseObject> = {
+const commonResponses = {
     200: emptySuccessResponse,
     401: unauthorizedResponse,
     503: notReadyResponse,
 } as const;
 
+type CommonResponses = typeof commonResponses;
+
 export const standardResponses = (
-    ...statusCodes: number[]
-): OpenAPIV3.ResponsesObject =>
-    statusCodes
-        .filter((n) => n in commonResponses)
-        .reduce(
-            (acc, n) => ({
-                ...acc,
-                [n]: commonResponses[String(n)] as OpenAPIV3.ResponseObject,
-            }),
-            {},
-        );
+    ...statusCodes: (keyof CommonResponses)[]
+): Partial<CommonResponses> =>
+    statusCodes.reduce(
+        (acc, n) => ({
+            ...acc,
+            [n]: commonResponses[n],
+        }),
+        {} as Partial<CommonResponses>,
+    );

--- a/src/openapi/common-responses.ts
+++ b/src/openapi/common-responses.ts
@@ -3,7 +3,7 @@ import { OpenAPIV3 } from 'openapi-types';
 export const NOT_READY_MSG =
     'The Unleash Proxy has not connected to the Unleash API and is not ready to accept requests yet.';
 
-export const notReadyResponse = {
+export const notReadyResponse: OpenAPIV3.ResponseObject = {
     description: "The proxy isn't ready to accept requests yet.",
     content: {
         'text/plain': {
@@ -13,13 +13,13 @@ export const notReadyResponse = {
             },
         },
     },
-} as const;
+};
 
-export const unauthorizedResponse = {
+export const unauthorizedResponse: OpenAPIV3.ResponseObject = {
     description: 'Authorization information is missing or invalid.',
-} as const;
+};
 
-export const badRequestResponse = {
+export const badRequestResponse: OpenAPIV3.ResponseObject = {
     description: 'The provided request data is invalid.',
     content: {
         'application/json': {
@@ -51,9 +51,9 @@ export const badRequestResponse = {
             },
         },
     },
-} as const;
+};
 
-export const emptySuccessResponse = {
+export const emptySuccessResponse: OpenAPIV3.ResponseObject = {
     description: 'The request was successful.',
     content: {
         'text/plain': {
@@ -63,7 +63,7 @@ export const emptySuccessResponse = {
             },
         },
     },
-} as const;
+};
 
 const commonResponses = {
     200: emptySuccessResponse,

--- a/src/openapi/openapi-service.ts
+++ b/src/openapi/openapi-service.ts
@@ -51,7 +51,7 @@ export class OpenApiService {
                 });
             } else if (err) {
                 res.status(500).json({
-                    error: `We dropped the ball on this one: ${err.message}`,
+                    error: `Whoops! We dropped the ball on this one (an unexpected error occurred): ${err.message}`,
                 });
             }
             {

--- a/src/openapi/openapi-service.ts
+++ b/src/openapi/openapi-service.ts
@@ -41,11 +41,20 @@ export class OpenApiService {
     useErrorHandler(app: Application): void {
         app.use((err: any, _: any, res: any, next: any) => {
             if (err && err.status && err.validationErrors) {
-                res.status(err.status).json({
+                res.status(err.statusCode).json({
                     error: err.message,
                     validation: err.validationErrors,
                 });
-            } else {
+            } else if (err instanceof SyntaxError) {
+                res.status(400).json({
+                    error: `We were unable to parse the data you provided. Please check it for syntax errors. The message we got was: "${err.message}"`,
+                });
+            } else if (err) {
+                res.status(500).json({
+                    error: `We dropped the ball on this one: ${err.message}`,
+                });
+            }
+            {
                 next();
             }
         });

--- a/src/openapi/spec/lookup-toggles-schema.ts
+++ b/src/openapi/spec/lookup-toggles-schema.ts
@@ -5,7 +5,7 @@ export const schema = {
     type: 'object',
     properties: {
         context: unleashContextSchema,
-        toggleNames: {
+        toggles: {
             type: 'array',
             example: ['myToggle', 'yourToggle'],
             items: {

--- a/src/openapi/spec/unleash-context-schema.ts
+++ b/src/openapi/spec/unleash-context-schema.ts
@@ -2,6 +2,7 @@ import { createSchemaObject, CreateSchemaType } from '../openapi-types';
 
 export const schema = {
     type: 'object',
+    additionalProperties: false,
     properties: {
         appName: { type: 'string' },
         environment: { type: 'string' },
@@ -10,7 +11,9 @@ export const schema = {
         remoteAddress: { type: 'string' },
         properties: {
             type: 'object',
-            additionalProperties: { type: 'string' },
+            additionalProperties: {
+                anyOf: [{ type: 'string' }, { type: 'number' }],
+            },
             example: {
                 region: 'Africa',
                 betaTester: 'true',

--- a/src/openapi/spec/unleash-context-schema.ts
+++ b/src/openapi/spec/unleash-context-schema.ts
@@ -2,7 +2,6 @@ import { createSchemaObject, CreateSchemaType } from '../openapi-types';
 
 export const schema = {
     type: 'object',
-    additionalProperties: false,
     properties: {
         appName: { type: 'string' },
         environment: { type: 'string' },

--- a/src/test/__snapshots__/openapi.test.ts.snap
+++ b/src/test/__snapshots__/openapi.test.ts.snap
@@ -326,6 +326,7 @@ Object {
       "lookupTogglesSchema": Object {
         "properties": Object {
           "context": Object {
+            "additionalProperties": false,
             "properties": Object {
               "appName": Object {
                 "type": "string",
@@ -335,7 +336,14 @@ Object {
               },
               "properties": Object {
                 "additionalProperties": Object {
-                  "type": "string",
+                  "anyOf": Array [
+                    Object {
+                      "type": "string",
+                    },
+                    Object {
+                      "type": "number",
+                    },
+                  ],
                 },
                 "example": Object {
                   "betaTester": "true",
@@ -444,6 +452,7 @@ Object {
         "type": "object",
       },
       "unleashContextSchema": Object {
+        "additionalProperties": false,
         "properties": Object {
           "appName": Object {
             "type": "string",
@@ -453,7 +462,14 @@ Object {
           },
           "properties": Object {
             "additionalProperties": Object {
-              "type": "string",
+              "anyOf": Array [
+                Object {
+                  "type": "string",
+                },
+                Object {
+                  "type": "number",
+                },
+              ],
             },
             "example": Object {
               "betaTester": "true",
@@ -629,6 +645,44 @@ Object {
             },
             "description": "The list of enabled toggles for the provided context.",
           },
+          "400": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "example": Object {
+                    "error": "Request validation failed",
+                    "validation": Array [
+                      Object {
+                        "dataPath": ".body",
+                        "keyword": "required",
+                        "message": "should have required property 'appName'",
+                        "params": Object {
+                          "missingProperty": "appName",
+                        },
+                        "schemaPath": "#/components/schemas/registerMetricsSchema/required",
+                      },
+                    ],
+                  },
+                  "properties": Object {
+                    "error": Object {
+                      "type": "string",
+                    },
+                    "validation": Object {
+                      "items": Object {
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": Array [
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The provided request data is invalid.",
+          },
           "401": Object {
             "description": "Authorization information is missing or invalid.",
           },
@@ -708,6 +762,44 @@ Object {
               },
             },
             "description": "The request was successful.",
+          },
+          "400": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "example": Object {
+                    "error": "Request validation failed",
+                    "validation": Array [
+                      Object {
+                        "dataPath": ".body",
+                        "keyword": "required",
+                        "message": "should have required property 'appName'",
+                        "params": Object {
+                          "missingProperty": "appName",
+                        },
+                        "schemaPath": "#/components/schemas/registerMetricsSchema/required",
+                      },
+                    ],
+                  },
+                  "properties": Object {
+                    "error": Object {
+                      "type": "string",
+                    },
+                    "validation": Object {
+                      "items": Object {
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": Array [
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The provided request data is invalid.",
           },
           "401": Object {
             "description": "Authorization information is missing or invalid.",

--- a/src/test/__snapshots__/openapi.test.ts.snap
+++ b/src/test/__snapshots__/openapi.test.ts.snap
@@ -355,7 +355,7 @@ Object {
             },
             "type": "object",
           },
-          "toggleNames": Object {
+          "toggles": Object {
             "example": Array [
               "myToggle",
               "yourToggle",

--- a/src/test/__snapshots__/openapi.test.ts.snap
+++ b/src/test/__snapshots__/openapi.test.ts.snap
@@ -326,7 +326,6 @@ Object {
       "lookupTogglesSchema": Object {
         "properties": Object {
           "context": Object {
-            "additionalProperties": false,
             "properties": Object {
               "appName": Object {
                 "type": "string",
@@ -452,7 +451,6 @@ Object {
         "type": "object",
       },
       "unleashContextSchema": Object {
-        "additionalProperties": false,
         "properties": Object {
           "appName": Object {
             "type": "string",

--- a/src/test/__snapshots__/openapi.test.ts.snap
+++ b/src/test/__snapshots__/openapi.test.ts.snap
@@ -608,7 +608,7 @@ Object {
         ],
       },
       "post": Object {
-        "description": "This endpoint accepts a JSON object with \`context\` and \`toggleNames\` properties. The Proxy will use the provided context values and evaluate the toggles provided in the \`toggleNames\` property. It returns the toggles that evaluate to false. As such, the list it returns is always a subset of the toggles you provide it.",
+        "description": "This endpoint accepts a JSON object with \`context\` and \`toggles\` properties. The Proxy will use the provided context values and evaluate the toggles provided in the \`toggleNames\` property. It returns the toggles that evaluate to false. As such, the list it returns is always a subset of the toggles you provide it.",
         "requestBody": Object {
           "content": Object {
             "application/json": Object {

--- a/src/test/__snapshots__/openapi.test.ts.snap
+++ b/src/test/__snapshots__/openapi.test.ts.snap
@@ -622,7 +622,7 @@ Object {
         ],
       },
       "post": Object {
-        "description": "This endpoint accepts a JSON object with \`context\` and \`toggles\` properties. The Proxy will use the provided context values and evaluate the toggles provided in the \`toggleNames\` property. It returns the toggles that evaluate to false. As such, the list it returns is always a subset of the toggles you provide it.",
+        "description": "This endpoint accepts a JSON object with \`context\` and \`toggles\` properties. The Proxy will use the provided context values and evaluate the toggles provided in the \`toggle\` property. It returns the toggles that evaluate to false. As such, the list it returns is always a subset of the toggles you provide it.",
         "requestBody": Object {
           "content": Object {
             "application/json": Object {

--- a/src/test/client.test.ts
+++ b/src/test/client.test.ts
@@ -28,6 +28,7 @@ test('should add environment to isEnabled calls', () => {
     fakeUnleash.toggleDefinitions.push({
         name: 'test',
         enabled: false,
+        type: 'experiment',
         stale: false,
         strategies: [],
         variants: [],
@@ -64,6 +65,7 @@ test('should override environment to isEnabled calls', () => {
     fakeUnleash.toggleDefinitions.push({
         name: 'test',
         enabled: false,
+        type: 'experiment',
         stale: false,
         strategies: [],
         variants: [],

--- a/src/test/client.test.ts
+++ b/src/test/client.test.ts
@@ -28,7 +28,6 @@ test('should add environment to isEnabled calls', () => {
     fakeUnleash.toggleDefinitions.push({
         name: 'test',
         enabled: false,
-        type: 'experiment',
         stale: false,
         strategies: [],
         variants: [],
@@ -65,7 +64,6 @@ test('should override environment to isEnabled calls', () => {
     fakeUnleash.toggleDefinitions.push({
         name: 'test',
         enabled: false,
-        type: 'experiment',
         stale: false,
         strategies: [],
         variants: [],

--- a/src/test/unleash-proxy.test.ts
+++ b/src/test/unleash-proxy.test.ts
@@ -84,6 +84,7 @@ test('Should handle POST with empty/nonsensical body', async () => {
         [{ blah: 'hello' }, undefined, {}].map((body) =>
             request(app)
                 .post('/proxy')
+                .type('json')
                 .send(body)
                 .set('Accept', 'application/json')
                 .set('Authorization', 'sdf')

--- a/src/test/unleash-proxy.test.ts
+++ b/src/test/unleash-proxy.test.ts
@@ -58,7 +58,7 @@ test('Should return list of toggles', () => {
         });
 });
 
-test('Should handle POST with empty body', () => {
+test('Should handle POST with empty/nonsensical body', async () => {
     const toggles = [
         {
             name: 'test',
@@ -80,16 +80,20 @@ test('Should handle POST with empty body', () => {
     );
     client.emit('ready');
 
-    return request(app)
-        .post('/proxy')
-        .send({ blah: 'hello' })
-        .set('Accept', 'application/json')
-        .set('Authorization', 'sdf')
-        .expect(200)
-        .expect('Content-Type', /json/)
-        .then((response) => {
-            expect(response.body.toggles).toHaveLength(0);
-        });
+    await Promise.all(
+        [{ blah: 'hello' }, undefined, {}].map((body) =>
+            request(app)
+                .post('/proxy')
+                .send(body)
+                .set('Accept', 'application/json')
+                .set('Authorization', 'sdf')
+                .expect(200)
+                .expect('Content-Type', /json/)
+                .then((response) => {
+                    expect(response.body.toggles).toHaveLength(0);
+                }),
+        ),
+    );
 });
 
 test('Should handle POST with toggle names', () => {
@@ -474,19 +478,22 @@ test('Should return the same origin based on cors options', async () => {
     );
 });
 
-test('POST /features: JSON parse errors are returned as 400 JSON responses', () => {
+test('Should return 400 bad request for malformed JSON', async () => {
+    const body = '{ toggles": [] }';
     const client = new MockClient();
 
     const proxySecrets = ['sdf'];
     const app = createApp(
-        { unleashUrl, unleashApiToken, proxySecrets },
+        { proxySecrets, unleashUrl, unleashApiToken },
         client,
     );
     client.emit('ready');
 
-    return request(app)
-        .post('/proxy/features')
-        .send('{toggles: []}')
+    await request(app)
+        .post('/proxy')
+        .type('json')
+        .send(body)
+        .set('Accept', 'application/json')
         .set('Authorization', 'sdf')
         .expect(400)
         .expect('Content-Type', /json/);

--- a/src/test/unleash-proxy.test.ts
+++ b/src/test/unleash-proxy.test.ts
@@ -473,3 +473,21 @@ test('Should return the same origin based on cors options', async () => {
         'https://demo.unleash-hosted.com',
     );
 });
+
+test('POST /features: JSON parse errors are returned as 400 JSON responses', () => {
+    const client = new MockClient();
+
+    const proxySecrets = ['sdf'];
+    const app = createApp(
+        { unleashUrl, unleashApiToken, proxySecrets },
+        client,
+    );
+    client.emit('ready');
+
+    return request(app)
+        .post('/proxy/features')
+        .send('{toggles: []}')
+        .set('Authorization', 'sdf')
+        .expect(400)
+        .expect('Content-Type', /json/);
+});

--- a/src/test/unleash-proxy.test.ts
+++ b/src/test/unleash-proxy.test.ts
@@ -97,6 +97,30 @@ test('Should handle POST with empty/nonsensical body', async () => {
     );
 });
 
+test('Should handle POST with extra context properties', () => {
+    const client = new MockClient();
+
+    const proxySecrets = ['sdf'];
+    const app = createApp(
+        { proxySecrets, unleashUrl, unleashApiToken },
+        client,
+    );
+    client.emit('ready');
+
+    return request(app)
+        .post('/proxy')
+        .send({
+            context: {
+                customProperty: 'string',
+                properties: { otherCustomProperty: 24 },
+            },
+        })
+        .set('Accept', 'application/json')
+        .set('Authorization', 'sdf')
+        .expect(200)
+        .expect('Content-Type', /json/);
+});
+
 test('Should handle POST with toggle names', () => {
     const toggles = [
         {

--- a/src/unleash-proxy.ts
+++ b/src/unleash-proxy.ts
@@ -101,7 +101,7 @@ export default class UnleashProxy {
                     200: featuresResponse,
                 },
                 description:
-                    'This endpoint accepts a JSON object with `context` and `toggleNames` properties. The Proxy will use the provided context values and evaluate the toggles provided in the `toggleNames` property. It returns the toggles that evaluate to false. As such, the list it returns is always a subset of the toggles you provide it.',
+                    'This endpoint accepts a JSON object with `context` and `toggles` properties. The Proxy will use the provided context values and evaluate the toggles provided in the `toggleNames` property. It returns the toggles that evaluate to false. As such, the list it returns is always a subset of the toggles you provide it.',
                 summary:
                     'Which of the provided toggles are enabled given the provided context?',
                 tags: ['Proxy client'],

--- a/src/unleash-proxy.ts
+++ b/src/unleash-proxy.ts
@@ -97,7 +97,7 @@ export default class UnleashProxy {
             openApiService.validPath({
                 requestBody: lookupTogglesRequest,
                 responses: {
-                    ...standardResponses(401, 503),
+                    ...standardResponses(400, 401, 503),
                     200: featuresResponse,
                 },
                 description:
@@ -129,7 +129,7 @@ export default class UnleashProxy {
             '/client/metrics',
             openApiService.validPath({
                 requestBody: registerMetricsRequest,
-                responses: standardResponses(200, 401),
+                responses: standardResponses(200, 400, 401),
                 description:
                     "This endpoint lets you register usage metrics with Unleash. Accepts either one of the proxy's configured `serverSideTokens` or one of its `clientKeys` for authorization.",
                 summary: 'Send usage metrics to Unleash.',

--- a/src/unleash-proxy.ts
+++ b/src/unleash-proxy.ts
@@ -102,7 +102,7 @@ export default class UnleashProxy {
                     200: featuresResponse,
                 },
                 description:
-                    'This endpoint accepts a JSON object with `context` and `toggles` properties. The Proxy will use the provided context values and evaluate the toggles provided in the `toggleNames` property. It returns the toggles that evaluate to false. As such, the list it returns is always a subset of the toggles you provide it.',
+                    'This endpoint accepts a JSON object with `context` and `toggles` properties. The Proxy will use the provided context values and evaluate the toggles provided in the `toggle` property. It returns the toggles that evaluate to false. As such, the list it returns is always a subset of the toggles you provide it.',
                 summary:
                     'Which of the provided toggles are enabled given the provided context?',
                 tags: ['Proxy client'],

--- a/src/unleash-proxy.ts
+++ b/src/unleash-proxy.ts
@@ -218,9 +218,10 @@ export default class UnleashProxy {
         } else if (!clientToken || !this.clientKeys.includes(clientToken)) {
             res.sendStatus(401);
         } else {
-            const { context, toggles: toggleNames = [] } = req.body;
+            const { context = {}, toggles: toggleNames = [] } = req.body;
 
             const toggles = this.client.getDefinedToggles(toggleNames, context);
+
             res.send({ toggles });
         }
     }

--- a/src/unleash-proxy.ts
+++ b/src/unleash-proxy.ts
@@ -17,6 +17,7 @@ import {
     createRequestParameters,
 } from './openapi/openapi-helpers';
 import { RegisterMetricsSchema } from './openapi/spec/register-metrics-schema';
+import { LookupTogglesSchema } from './openapi/spec/lookup-toggles-schema';
 
 export default class UnleashProxy {
     private logger: Logger;
@@ -206,7 +207,10 @@ export default class UnleashProxy {
         }
     }
 
-    lookupToggles(req: Request, res: Response<FeaturesSchema | string>): void {
+    lookupToggles(
+        req: Request<any, any, LookupTogglesSchema>,
+        res: Response<FeaturesSchema | string>,
+    ): void {
         const clientToken = req.header(this.clientKeysHeaderName);
 
         if (!this.ready) {

--- a/src/unleash-proxy.ts
+++ b/src/unleash-proxy.ts
@@ -1,4 +1,5 @@
 import { Request, Response, Router } from 'express';
+import { Context } from 'unleash-client';
 import { createContext } from './create-context';
 import { IProxyConfig } from './config';
 import { IClient } from './client';
@@ -220,7 +221,10 @@ export default class UnleashProxy {
         } else {
             const { context = {}, toggles: toggleNames = [] } = req.body;
 
-            const toggles = this.client.getDefinedToggles(toggleNames, context);
+            const toggles = this.client.getDefinedToggles(
+                toggleNames,
+                context as Context,
+            );
 
             res.send({ toggles });
         }


### PR DESCRIPTION
This PR fixes the bug report referenced later in this text. In short, there were two things: 
1. The OpenAPI spec said the /proxy POST endpoint had a `toggleNames` property, but it's actually just `toggles`
2. If you POST invalid (according to the spec) JSON to the /proxy endpoint, then you get a 404.

These two issues have been addressed as follows:
1. The OpenAPI spec has been changed to list the property as `toggles`.
2. POSTing invalid data (that can't be parsed) now results in a 400. Posting valid json that doesn't conform to what we expect yields a 200. The decision for the latter is that there's been tests for this for a long time, so it's the expected behavior.

## Root cause

The root cause of the 404 bug was that the OpenAPI validator required `toggleNames`. Further, the error handler that takes care of errors from the OpenAPI validator didn't catch other errors (such as syntax errors in the request payload). This has now been rectified.

## Changes

The primary required changes are the ones in `src/openapi/spec/lookup-toggles-schema.ts` (adjusting the property name). There's also relevant updates to the tests in `src/test/unleash-proxy.test.ts` that now test  more comprehensively for unexpected or malformed payloads. 

Further, I have added 400 Bad Request as another standard response as it is shared by the POST endpoints and in doing so, also updated the common responses file (`src/openapi/common-responses.ts`) to be more in line with what we have in unleash/unleash and made it more type safe.

### Bonus bug fix

There was a bug that is not currently caught by any of our tests: if you POST to /proxy asking for toggles that don't exist, you would get a 500 error, as the proxy tries to read the `.impressionData` property of undefined in `src/client.ts`. I've rectified this and manually confirmed that it works. However, because we use a mock client for testing, the tests don't surface this issue at all. 

**I would love some input on how to address this**. If the only way is to set up e2e tests for it, then that _may_ be worth it.

## Bug report

> The OAS specification here is wrong. It looks like the endpoint actually takes toggles and not toggleNames in the request body.
>
> Also, when posting toggles instead of toggleNames the proxy returns an HTML error that says you can't post to this endpoint:

![image](https://user-images.githubusercontent.com/17786332/178486046-1f9bda85-40f8-42bf-9c2a-7541c9417ad7.png)
