### PR TITLE
Allow user to add httpOptions in the config

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -83,7 +83,9 @@ class Client extends EventEmitter implements IClient {
             tags: config.tags,
             customHeadersFunction,
             bootstrap: config.bootstrap,
-            httpOptions: config.httpOptions,
+            ...(!!config.httpOptions
+                ? { httpOptions: config.httpOptions }
+                : {}),
         });
 
         // Custom metrics Instance
@@ -95,7 +97,9 @@ class Client extends EventEmitter implements IClient {
             metricsInterval: config.metricsInterval,
             url: config.unleashUrl,
             customHeadersFunction,
-            httpOptions: config.httpOptions,
+            ...(!!config.httpOptions
+                ? { httpOptions: config.httpOptions }
+                : {}),
         });
 
         this.metrics.on('error', (msg) => this.logger.error(`metrics: ${msg}`));

--- a/src/client.ts
+++ b/src/client.ts
@@ -83,6 +83,7 @@ class Client extends EventEmitter implements IClient {
             tags: config.tags,
             customHeadersFunction,
             bootstrap: config.bootstrap,
+            httpOptions: config.httpOptions
         });
 
         // Custom metrics Instance
@@ -94,6 +95,7 @@ class Client extends EventEmitter implements IClient {
             metricsInterval: config.metricsInterval,
             url: config.unleashUrl,
             customHeadersFunction,
+            httpOptions: config.httpOptions
         });
 
         this.metrics.on('error', (msg) => this.logger.error(`metrics: ${msg}`));

--- a/src/client.ts
+++ b/src/client.ts
@@ -83,7 +83,7 @@ class Client extends EventEmitter implements IClient {
             tags: config.tags,
             customHeadersFunction,
             bootstrap: config.bootstrap,
-            httpOptions: config.httpOptions
+            httpOptions: config.httpOptions,
         });
 
         // Custom metrics Instance
@@ -95,7 +95,7 @@ class Client extends EventEmitter implements IClient {
             metricsInterval: config.metricsInterval,
             url: config.unleashUrl,
             customHeadersFunction,
-            httpOptions: config.httpOptions
+            httpOptions: config.httpOptions,
         });
 
         this.metrics.on('error', (msg) => this.logger.error(`metrics: ${msg}`));

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@ import { Strategy, TagFilter } from 'unleash-client';
 import { BootstrapOptions } from 'unleash-client/lib/repository/bootstrap-provider';
 import { Logger, LogLevel, SimpleLogger } from './logger';
 import { generateInstanceId } from './util';
+import { HttpOptions } from 'unleash-client/lib/http-options';
 
 export interface ServerSideSdkConfig {
     tokens: string[];
@@ -33,6 +34,7 @@ export interface IProxyOption {
     // experimental options
     expBootstrap?: BootstrapOptions;
     expServerSideSdkConfig?: ServerSideSdkConfig;
+    httpOptions?: HttpOptions;
 }
 
 export interface IProxyConfig {
@@ -57,6 +59,7 @@ export interface IProxyConfig {
     serverSideSdkConfig?: ServerSideSdkConfig;
     bootstrap?: BootstrapOptions;
     cors: CorsOptions;
+    httpOptions?: HttpOptions;
 }
 
 function resolveStringToArray(value?: string): string[] | undefined {
@@ -258,5 +261,6 @@ export function createProxyConfig(option: IProxyOption): IProxyConfig {
         enableOAS:
             option.enableOAS || safeBoolean(process.env.ENABLE_OAS, false),
         cors: loadCorsOptions(option),
+        ...(!!option.httpOptions ? { httpOptions: option.httpOptions } : {})
     };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -261,6 +261,6 @@ export function createProxyConfig(option: IProxyOption): IProxyConfig {
         enableOAS:
             option.enableOAS || safeBoolean(process.env.ENABLE_OAS, false),
         cors: loadCorsOptions(option),
-        ...(!!option.httpOptions ? { httpOptions: option.httpOptions } : {})
+        ...(!!option.httpOptions ? { httpOptions: option.httpOptions } : {}),
     };
 }

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -353,7 +353,7 @@ test('when passed with agent in httpOptions config.httpOptions.agent should be c
     );
 });
 
-test('when not passed with httpOptions the config should not contain that property', () => {
+test('should not set config.httpOptions if no http options are provided at creation', () => {
     const config = createProxyConfig({
         unleashUrl: 'some',
         unleashApiToken: 'some',

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import { Strategy } from 'unleash-client';
 import { createProxyConfig } from '../config';
+import * as https from "https";
 
 test('should require "unleashUrl', () => {
     const t = () => createProxyConfig({});
@@ -337,3 +338,15 @@ test('should load cors origin, maxAge and exposedHeaders default values', () => 
     expect(config.cors.maxAge).toBe(172800);
     expect(config.cors.exposedHeaders).toBe('ETag');
 });
+
+test('should load passed in http agent', () => {
+    const config = createProxyConfig({
+        unleashUrl: 'some',
+        unleashApiToken: 'some',
+        clientKeys: ['s1'],
+        httpOptions: {
+            agent: _ => https.globalAgent
+        }
+    });
+    expect(config.httpOptions?.agent?.(new URL('https://example.com'))).toBe(https.globalAgent);
+})

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -345,7 +345,7 @@ test('should load the passed-in http agent when config.httpOptions is provided',
         unleashApiToken: 'some',
         clientKeys: ['s1'],
         httpOptions: {
-            agent: (_) => https.globalAgent,
+            agent: () => https.globalAgent,
         },
     });
     expect(config.httpOptions?.agent?.(new URL('https://example.com'))).toBe(

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import { Strategy } from 'unleash-client';
 import { createProxyConfig } from '../config';
-import * as https from "https";
+import * as https from 'https';
 
 test('should require "unleashUrl', () => {
     const t = () => createProxyConfig({});
@@ -345,8 +345,10 @@ test('should load passed in http agent', () => {
         unleashApiToken: 'some',
         clientKeys: ['s1'],
         httpOptions: {
-            agent: _ => https.globalAgent
-        }
+            agent: (_) => https.globalAgent,
+        },
     });
-    expect(config.httpOptions?.agent?.(new URL('https://example.com'))).toBe(https.globalAgent);
-})
+    expect(config.httpOptions?.agent?.(new URL('https://example.com'))).toBe(
+        https.globalAgent,
+    );
+});

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -339,7 +339,7 @@ test('should load cors origin, maxAge and exposedHeaders default values', () => 
     expect(config.cors.exposedHeaders).toBe('ETag');
 });
 
-test('should load passed in http agent', () => {
+test('when passed with agent in httpOptions config.httpOptions.agent should be callable with url', () => {
     const config = createProxyConfig({
         unleashUrl: 'some',
         unleashApiToken: 'some',
@@ -351,4 +351,13 @@ test('should load passed in http agent', () => {
     expect(config.httpOptions?.agent?.(new URL('https://example.com'))).toBe(
         https.globalAgent,
     );
+});
+
+test('when not passed with httpOptions the config should not contain that property', () => {
+    const config = createProxyConfig({
+        unleashUrl: 'some',
+        unleashApiToken: 'some',
+        clientKeys: ['s1'],
+    });
+    expect(config.httpOptions).toBeUndefined();
 });

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -339,7 +339,7 @@ test('should load cors origin, maxAge and exposedHeaders default values', () => 
     expect(config.cors.exposedHeaders).toBe('ETag');
 });
 
-test('when passed with agent in httpOptions config.httpOptions.agent should be callable with url', () => {
+test('should load the passed-in http agent when config.httpOptions is provided', () => {
     const config = createProxyConfig({
         unleashUrl: 'some',
         unleashApiToken: 'some',


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
Allows adding in httpOptions which then gets passed to the unleash client.
This enables
- Using self-signed certs (successfully tested with GitLab) 

It should be setup that if the user doesn't add a custom httpOptions it would maintain the same runtime before this merge request. 

Let me know if changes need to be made! I tried to minimize the changes best I could. :) 

<!-- Does it close an issue? Multiple? -->
Closes # .

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->
src/client.ts
src/config.ts

## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
Just want to make sure this isn't a breaking change or if that is the right place to add in the config object. 