### PR TITLE
docs: document 500 errors in OpenAPI

### DIFF
--- a/src/openapi/common-responses.ts
+++ b/src/openapi/common-responses.ts
@@ -1,6 +1,6 @@
 import { OpenAPIV3 } from 'openapi-types';
 
-export const format500ErrorMessage = (errorMessage: string) =>
+export const format500ErrorMessage = (errorMessage: string): string =>
     `Whoops! We dropped the ball on this one (an unexpected error occurred): ${errorMessage}`;
 
 export const NOT_READY_MSG =

--- a/src/openapi/common-responses.ts
+++ b/src/openapi/common-responses.ts
@@ -1,5 +1,8 @@
 import { OpenAPIV3 } from 'openapi-types';
 
+export const format500ErrorMessage = (errorMessage: string) =>
+    `Whoops! We dropped the ball on this one (an unexpected error occurred): ${errorMessage}`;
+
 export const NOT_READY_MSG =
     'The Unleash Proxy has not connected to the Unleash API and is not ready to accept requests yet.';
 
@@ -65,10 +68,32 @@ export const emptySuccessResponse: OpenAPIV3.ResponseObject = {
     },
 };
 
+export const internalServerErrorResponse: OpenAPIV3.ResponseObject = {
+    description:
+        "Something went wrong on the server side and we were unable to recover. If you have custom strategies loaded, make sure they don't throw errors.",
+    content: {
+        'application/json': {
+            schema: {
+                type: 'object',
+                required: ['error'],
+                properties: {
+                    error: { type: 'string' },
+                },
+                example: {
+                    error: format500ErrorMessage(
+                        "Cannot read properties of undefined (reading 'includes')",
+                    ),
+                },
+            },
+        },
+    },
+};
+
 const commonResponses = {
     200: emptySuccessResponse,
     400: badRequestResponse,
     401: unauthorizedResponse,
+    500: internalServerErrorResponse,
     503: notReadyResponse,
 } as const;
 

--- a/src/openapi/openapi-service.ts
+++ b/src/openapi/openapi-service.ts
@@ -3,6 +3,7 @@ import { OpenAPIV3 } from 'openapi-types';
 import openapi, { IExpressOpenApi } from '@unleash/express-openapi';
 import { IProxyConfig } from '../config';
 import { createOpenApiSchema } from '.';
+import { format500ErrorMessage } from './common-responses';
 
 export class OpenApiService {
     private readonly config: IProxyConfig;
@@ -51,7 +52,7 @@ export class OpenApiService {
                 });
             } else if (err) {
                 res.status(500).json({
-                    error: `Whoops! We dropped the ball on this one (an unexpected error occurred): ${err.message}`,
+                  error: format500ErrorMessage(err.message),
                 });
             }
             {

--- a/src/openapi/openapi-service.ts
+++ b/src/openapi/openapi-service.ts
@@ -52,10 +52,9 @@ export class OpenApiService {
                 });
             } else if (err) {
                 res.status(500).json({
-                  error: format500ErrorMessage(err.message),
+                    error: format500ErrorMessage(err.message),
                 });
-            }
-            {
+            } else {
                 next();
             }
         });

--- a/src/openapi/spec/api-request-response.ts
+++ b/src/openapi/spec/api-request-response.ts
@@ -1,7 +1,8 @@
 import { OpenAPIV3 } from 'openapi-types';
 
 export const apiRequestResponse: OpenAPIV3.ResponseObject = {
-    description: 'The list of enabled toggles for the provided context.',
+    description:
+        "The proxy's current feature toggle configuration. A list of feature toggles that is parseable by other server-side clients.",
     content: {
         'application/json': {
             schema: {

--- a/src/test/__snapshots__/openapi.test.ts.snap
+++ b/src/test/__snapshots__/openapi.test.ts.snap
@@ -604,6 +604,27 @@ Object {
           "401": Object {
             "description": "Authorization information is missing or invalid.",
           },
+          "500": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "example": Object {
+                    "error": "Whoops! We dropped the ball on this one (an unexpected error occurred): Cannot read properties of undefined (reading 'includes')",
+                  },
+                  "properties": Object {
+                    "error": Object {
+                      "type": "string",
+                    },
+                  },
+                  "required": Array [
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Something went wrong on the server side and we were unable to recover. If you have custom strategies loaded, make sure they don't throw errors.",
+          },
           "503": Object {
             "content": Object {
               "text/plain": Object {
@@ -684,6 +705,27 @@ Object {
           "401": Object {
             "description": "Authorization information is missing or invalid.",
           },
+          "500": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "example": Object {
+                    "error": "Whoops! We dropped the ball on this one (an unexpected error occurred): Cannot read properties of undefined (reading 'includes')",
+                  },
+                  "properties": Object {
+                    "error": Object {
+                      "type": "string",
+                    },
+                  },
+                  "required": Array [
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Something went wrong on the server side and we were unable to recover. If you have custom strategies loaded, make sure they don't throw errors.",
+          },
           "503": Object {
             "content": Object {
               "text/plain": Object {
@@ -714,7 +756,7 @@ Object {
                 },
               },
             },
-            "description": "The list of enabled toggles for the provided context.",
+            "description": "The proxy's current feature toggle configuration. A list of feature toggles that is parseable by other server-side clients.",
           },
           "401": Object {
             "description": "Authorization information is missing or invalid.",

--- a/src/unleash-proxy.ts
+++ b/src/unleash-proxy.ts
@@ -81,7 +81,7 @@ export default class UnleashProxy {
                     }),
                 ],
                 responses: {
-                    ...standardResponses(401, 503),
+                    ...standardResponses(401, 500, 503),
                     200: featuresResponse,
                 },
                 description:
@@ -98,7 +98,7 @@ export default class UnleashProxy {
             openApiService.validPath({
                 requestBody: lookupTogglesRequest,
                 responses: {
-                    ...standardResponses(400, 401, 503),
+                    ...standardResponses(400, 401, 500, 503),
                     200: featuresResponse,
                 },
                 description:


### PR DESCRIPTION
This change explicitly documents the 500 errors that can happen for GET and POST requests to the /proxy endpoint. When this happens it's most likely a result of a custom strategy throwing an exception (see #79).

As a bonus, it also fixes the description of the /proxy/client/features endpoint.