### PR TITLE
fix: should not yield 404 when serverside SDK tries to register

### DIFF
--- a/example.js
+++ b/example.js
@@ -8,6 +8,7 @@ const app = createApp({
     clientKeys: ['proxy-secret', 'another-proxy-secret', 's1'],
     refreshInterval: 1000,
     logLevel: 'trace',
+    enableOAS: true,
     expServerSideSdkConfig: {
         tokens: ['server'],
     },

--- a/src/openapi/index.ts
+++ b/src/openapi/index.ts
@@ -4,6 +4,7 @@ import { featureSchema } from './spec/feature-schema';
 import { featuresSchema } from './spec/features-schema';
 import { lookupTogglesSchema } from './spec/lookup-toggles-schema';
 import { registerMetricsSchema } from './spec/register-metrics-schema';
+import { registerClientSchema } from './spec/register-client-schema';
 import { unleashContextSchema } from './spec/unleash-context-schema';
 import { variantSchema } from './spec/variant-schema';
 
@@ -53,6 +54,7 @@ export const createOpenApiSchema = (
             featuresSchema,
             lookupTogglesSchema,
             registerMetricsSchema,
+            registerClientSchema,
             unleashContextSchema,
             variantSchema,
         },

--- a/src/openapi/spec/register-client-request.ts
+++ b/src/openapi/spec/register-client-request.ts
@@ -1,0 +1,11 @@
+import { OpenAPIV3 } from 'openapi-types';
+
+export const registerClientRequest: OpenAPIV3.RequestBodyObject = {
+    content: {
+        'application/json': {
+            schema: {
+                $ref: '#/components/schemas/registerClientSchema',
+            },
+        },
+    },
+};

--- a/src/openapi/spec/register-client-schema.ts
+++ b/src/openapi/spec/register-client-schema.ts
@@ -6,30 +6,41 @@ export const schema = {
     properties: {
         appName: {
             type: 'string',
+            description: 'Name of the application using Unleash',
         },
         instanceId: {
             type: 'string',
+            description:
+                'Instance id for this application (typically hostname, podId or similar)',
         },
         sdkVersion: {
             type: 'string',
+            description:
+                'Optional field that describes the sdk version (name:version)',
         },
         environment: {
             type: 'string',
+            deprecated: true,
         },
         interval: {
             type: 'number',
+            description:
+                'At which interval, in milliseconds, will this client be expected to send metrics',
         },
         started: {
             oneOf: [
                 { type: 'string', format: 'date-time' },
                 { type: 'number' },
             ],
+            description:
+                'When this client started. Should be reported as ISO8601 time.',
         },
         strategies: {
             type: 'array',
             items: {
                 type: 'string',
             },
+            description: 'List of strategies implemented by this application',
         },
     },
 } as const;

--- a/src/openapi/spec/register-client-schema.ts
+++ b/src/openapi/spec/register-client-schema.ts
@@ -1,0 +1,39 @@
+import { createSchemaObject, CreateSchemaType } from '../openapi-types';
+
+export const schema = {
+    type: 'object',
+    required: ['appName', 'interval', 'started', 'strategies'],
+    properties: {
+        appName: {
+            type: 'string',
+        },
+        instanceId: {
+            type: 'string',
+        },
+        sdkVersion: {
+            type: 'string',
+        },
+        environment: {
+            type: 'string',
+        },
+        interval: {
+            type: 'number',
+        },
+        started: {
+            oneOf: [
+                { type: 'string', format: 'date-time' },
+                { type: 'number' },
+            ],
+        },
+        strategies: {
+            type: 'array',
+            items: {
+                type: 'string',
+            },
+        },
+    },
+} as const;
+
+export type RegisterClientSchema = CreateSchemaType<typeof schema>;
+
+export const registerClientSchema = createSchemaObject(schema);

--- a/src/test/__snapshots__/openapi.test.ts.snap
+++ b/src/test/__snapshots__/openapi.test.ts.snap
@@ -378,21 +378,27 @@ Object {
       "registerClientSchema": Object {
         "properties": Object {
           "appName": Object {
+            "description": "Name of the application using Unleash",
             "type": "string",
           },
           "environment": Object {
+            "deprecated": true,
             "type": "string",
           },
           "instanceId": Object {
+            "description": "Instance id for this application (typically hostname, podId or similar)",
             "type": "string",
           },
           "interval": Object {
+            "description": "At which interval, in milliseconds, will this client be expected to send metrics",
             "type": "number",
           },
           "sdkVersion": Object {
+            "description": "Optional field that describes the sdk version (name:version)",
             "type": "string",
           },
           "started": Object {
+            "description": "When this client started. Should be reported as ISO8601 time.",
             "oneOf": Array [
               Object {
                 "format": "date-time",
@@ -404,6 +410,7 @@ Object {
             ],
           },
           "strategies": Object {
+            "description": "List of strategies implemented by this application",
             "items": Object {
               "type": "string",
             },

--- a/src/test/__snapshots__/openapi.test.ts.snap
+++ b/src/test/__snapshots__/openapi.test.ts.snap
@@ -383,6 +383,7 @@ Object {
           },
           "environment": Object {
             "deprecated": true,
+            "description": "The environment specified in the client config. Note: this is _not_ the same as the Unleash environment.",
             "type": "string",
           },
           "instanceId": Object {

--- a/src/test/__snapshots__/openapi.test.ts.snap
+++ b/src/test/__snapshots__/openapi.test.ts.snap
@@ -383,7 +383,6 @@ Object {
           },
           "environment": Object {
             "deprecated": true,
-            "description": "The environment specified in the client config. Note: this is _not_ the same as the Unleash environment.",
             "type": "string",
           },
           "instanceId": Object {

--- a/src/test/__snapshots__/openapi.test.ts.snap
+++ b/src/test/__snapshots__/openapi.test.ts.snap
@@ -375,6 +375,49 @@ Object {
         },
         "type": "object",
       },
+      "registerClientSchema": Object {
+        "properties": Object {
+          "appName": Object {
+            "type": "string",
+          },
+          "environment": Object {
+            "type": "string",
+          },
+          "instanceId": Object {
+            "type": "string",
+          },
+          "interval": Object {
+            "type": "number",
+          },
+          "sdkVersion": Object {
+            "type": "string",
+          },
+          "started": Object {
+            "oneOf": Array [
+              Object {
+                "format": "date-time",
+                "type": "string",
+              },
+              Object {
+                "type": "number",
+              },
+            ],
+          },
+          "strategies": Object {
+            "items": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+        },
+        "required": Array [
+          "appName",
+          "interval",
+          "started",
+          "strategies",
+        ],
+        "type": "object",
+      },
       "registerMetricsSchema": Object {
         "properties": Object {
           "appName": Object {
@@ -846,6 +889,79 @@ Object {
           },
         },
         "summary": "Send usage metrics to Unleash.",
+        "tags": Array [
+          "Operational",
+          "Server-side client",
+        ],
+      },
+    },
+    "/proxy/client/register": Object {
+      "post": Object {
+        "description": "This endpoint lets you register application with Unleash. Accepts either one of the proxy's configured \`serverSideTokens\` or one of its \`clientKeys\` for authorization.",
+        "requestBody": Object {
+          "content": Object {
+            "application/json": Object {
+              "schema": Object {
+                "$ref": "#/components/schemas/registerClientSchema",
+              },
+            },
+          },
+        },
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "example": "ok",
+                  "type": "string",
+                },
+              },
+            },
+            "description": "The request was successful.",
+          },
+          "400": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "example": Object {
+                    "error": "Request validation failed",
+                    "validation": Array [
+                      Object {
+                        "dataPath": ".body",
+                        "keyword": "required",
+                        "message": "should have required property 'appName'",
+                        "params": Object {
+                          "missingProperty": "appName",
+                        },
+                        "schemaPath": "#/components/schemas/registerMetricsSchema/required",
+                      },
+                    ],
+                  },
+                  "properties": Object {
+                    "error": Object {
+                      "type": "string",
+                    },
+                    "validation": Object {
+                      "items": Object {
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": Array [
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The provided request data is invalid.",
+          },
+          "401": Object {
+            "description": "Authorization information is missing or invalid.",
+          },
+        },
+        "summary": "Register clients with Unleash.",
         "tags": Array [
           "Operational",
           "Server-side client",

--- a/src/test/unleash-proxy.test.ts
+++ b/src/test/unleash-proxy.test.ts
@@ -523,3 +523,41 @@ test('Should return 400 bad request for malformed JSON', async () => {
         .expect(400)
         .expect('Content-Type', /json/);
 });
+
+test('Should register server SDK', async () => {
+    const toggles = [
+        {
+            name: 'test',
+            enabled: true,
+            impressionData: true,
+        },
+    ];
+    const client = new MockClient(toggles);
+
+    const proxySecrets = ['sdf'];
+    const app = createApp(
+        {
+            unleashUrl,
+            unleashApiToken,
+            proxySecrets,
+            expServerSideSdkConfig: { tokens: ['s1'] },
+        },
+        client,
+    );
+    client.emit('ready');
+
+    const res = await request(app)
+        .post('/proxy/client/register')
+        .send({
+            appName: 'test',
+            instanceId: 'i1',
+            sdkVersion: 'custom1',
+            environment: 'prod',
+            interval: 10000,
+            started: new Date(),
+            strategies: ['default'],
+        })
+        .set('Authorization', 'sdf');
+
+    expect(res.statusCode).toBe(200);
+});


### PR DESCRIPTION
## About the changes

The Unleash proxy has experimental support for server-side SDKs. There was one limitation currently where the proxy does not handle the /client/register call, and thus yields a 404 for these requests, causing a lot of noise in the applications using a serverside SDK. 

This PR adds support for the request (but disregards the registrations, until Unleash supports a "connect via" registration message. 