### PR TITLE
Remove deprecated configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ docker pull unleashorg/unleash-proxy
 
 ```bash
 docker run \
-   -e UNLEASH_PROXY_SECRETS=some-secret \
+   -e UNLEASH_PROXY_CLIENT_KEYS=some-secret \
    -e UNLEASH_URL=https://app.unleash-hosted.com/demo/api/ \
    -e UNLEASH_API_TOKEN=56907a2fa53c1d16101d509a10b78e36190b0f918d9f122d \
    -p 3000:3000 \


### PR DESCRIPTION
It seems `UNLEASH_PROXY_SECRETS` is deprecated and we should have `UNLEASH_PROXY_CLIENT_KEYS` in our examples instead.