### PR TITLE
Updated to publish released tags to ECR as well as docker hub

### DIFF
--- a/.github/workflows/push-ecr-releases.yml
+++ b/.github/workflows/push-ecr-releases.yml
@@ -1,0 +1,46 @@
+name: ECR public release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Login to AWS ECR
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v1
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        env:
+          REGISTRY: ${{ steps.login-ecr-public-outputs.registry }}
+          REGISTRY_ALIAS: unleashorg
+          REPOSITORY: unleash-proxy
+        with:
+          images: |
+            $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY
+          tags: |
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: linux/arm64,linux/amd64
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          platforms: linux/arm64,linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This PR adds a workflow that should build ARM64 and AMD64 images of proxy and push them to our Public ECR repository.
I've added a AWS key/secret pair to secrets which should allow the action to run. Kinda want to try on more flows than just tag, to see that it works, maybe push to main as well until we've confirmed it works?