### PR TITLE
chore: bump version v0.10.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unleash/proxy",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "The Unleash Proxy (Open-Source)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This prepares the release for OpenAPI fixing the issue with Content Security Policy about executing an inline script (https://content-security-policy.com/examples/allow-inline-script/)