### PR TITLE
fix: add registry-type to login action

### DIFF
--- a/.github/workflows/push-ecr-releases.yml
+++ b/.github/workflows/push-ecr-releases.yml
@@ -14,6 +14,8 @@ jobs:
       - name: Login to AWS ECR
         id: login-ecr-public
         uses: aws-actions/amazon-ecr-login@v1
+        with:
+          registry-type: public
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3


### PR DESCRIPTION
So, releasing to ecr-public failed with region missing, this seems to be since we forgot to add registry-type. This PR adds registry-type to the login action