### PR TITLE
sanitize proxy base path

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.17.10",
+    "@types/node": "18.7.14",
     "@types/compression": "^1.7.2",
     "@types/cors": "^2.8.12",
     "@types/express": "^4.17.13",

--- a/src/config.ts
+++ b/src/config.ts
@@ -111,8 +111,6 @@ export function sanitizeBasePath(path?: string): string {
     return removeTrailingPath(addLeadingPath(path.trim()));
 }
 
-
-
 function loadTrustProxy(value: string = 'FALSE') {
     const upperValue = value.toUpperCase();
     if (upperValue === 'FALSE') {
@@ -243,7 +241,9 @@ export function createProxyConfig(option: IProxyOption): IProxyConfig {
         process.env.UNLEASH_INSTANCE_ID ||
         generateInstanceId();
 
-    let proxyBasePath = sanitizeBasePath(option.proxyBasePath || process.env.PROXY_BASE_PATH);
+    let proxyBasePath = sanitizeBasePath(
+        option.proxyBasePath || process.env.PROXY_BASE_PATH,
+    );
     return {
         unleashUrl,
         unleashApiToken,

--- a/src/config.ts
+++ b/src/config.ts
@@ -105,7 +105,7 @@ function addLeadingPath(path: string): string {
 }
 
 export function sanitizeBasePath(path?: string): string {
-    if (!path) {
+    if (path === null || path === undefined || path.trim() === '') {
         return '';
     }
     return removeTrailingPath(addLeadingPath(path.trim()));

--- a/src/config.ts
+++ b/src/config.ts
@@ -96,6 +96,22 @@ function loadCustomStrategies(path?: string): Strategy[] | undefined {
     }
     return undefined;
 }
+function removeTrailingPath(path: string): string {
+    return path.endsWith('/') ? path.slice(0, -1) : path;
+}
+
+function addLeadingPath(path: string): string {
+    return path.startsWith('/') ? path : `/${path}`;
+}
+
+export function sanitizeBasePath(path?: string): string {
+    if (!path) {
+        return '';
+    }
+    return removeTrailingPath(addLeadingPath(path.trim()));
+}
+
+
 
 function loadTrustProxy(value: string = 'FALSE') {
     const upperValue = value.toUpperCase();
@@ -263,19 +279,4 @@ export function createProxyConfig(option: IProxyOption): IProxyConfig {
         cors: loadCorsOptions(option),
         ...(!!option.httpOptions ? { httpOptions: option.httpOptions } : {}),
     };
-}
-
-export function sanitizeBasePath(path?: string): string {
-    if (!path) {
-        return '';
-    }
-    return removeTrailingPath(addLeadingPath(path));
-}
-
-function removeTrailingPath(path: string): string {
-    return path.endsWith('/') ? path.slice(0, -1) : path;
-}
-
-function addLeadingPath(path: string): string {
-    return path.startsWith('/') ? path : `/${path}`;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -227,6 +227,7 @@ export function createProxyConfig(option: IProxyOption): IProxyConfig {
         process.env.UNLEASH_INSTANCE_ID ||
         generateInstanceId();
 
+    let proxyBasePath = sanitizeBasePath(option.proxyBasePath || process.env.PROXY_BASE_PATH);
     return {
         unleashUrl,
         unleashApiToken,
@@ -237,8 +238,7 @@ export function createProxyConfig(option: IProxyOption): IProxyConfig {
         unleashInstanceId,
         customStrategies,
         clientKeys,
-        proxyBasePath:
-            option.proxyBasePath || process.env.PROXY_BASE_PATH || '',
+        proxyBasePath,
         refreshInterval:
             option.refreshInterval ||
             safeNumber(process.env.UNLEASH_FETCH_INTERVAL, 5_000),
@@ -263,4 +263,19 @@ export function createProxyConfig(option: IProxyOption): IProxyConfig {
         cors: loadCorsOptions(option),
         ...(!!option.httpOptions ? { httpOptions: option.httpOptions } : {}),
     };
+}
+
+export function sanitizeBasePath(path?: string): string {
+    if (!path) {
+        return '';
+    }
+    return removeTrailingPath(addLeadingPath(path));
+}
+
+function removeTrailingPath(path: string): string {
+    return path.endsWith('/') ? path.slice(0, -1) : path;
+}
+
+function addLeadingPath(path: string): string {
+    return path.startsWith('/') ? path : `/${path}`;
 }

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -378,3 +378,17 @@ test.each([
 
     expect(config.proxyBasePath).toBe(`/base/path`);
 });
+
+test.each(['', '     ', '   ', undefined])(
+    `%s as base path should be treated the same as empty string`,
+    (p) => {
+        const config = createProxyConfig({
+            unleashUrl: 'some',
+            unleashApiToken: 'some',
+            clientKeys: ['s1'],
+            proxyBasePath: p,
+        });
+
+        expect(config.proxyBasePath).toBe(``);
+    },
+);

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -361,3 +361,14 @@ test('should not set config.httpOptions if no http options are provided at creat
     });
     expect(config.httpOptions).toBeUndefined();
 });
+
+test.each(['/base/path', '/base/path', 'base/path/', 'base/path'])('%s as proxyBasePath should yield /base/path as base path', async (path) => {
+    const config = createProxyConfig({
+        unleashUrl: 'some',
+        unleashApiToken: 'some',
+        clientKeys: ['s1'],
+        proxyBasePath: path
+    });
+
+    expect(config.proxyBasePath).toBe(`/base/path`);
+});

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -362,12 +362,18 @@ test('should not set config.httpOptions if no http options are provided at creat
     expect(config.httpOptions).toBeUndefined();
 });
 
-test.each(['/base/path', '/base/path', 'base/path/', 'base/path'])('%s as proxyBasePath should yield /base/path as base path', async (path) => {
+test.each([
+    '/base/path',
+    '/base/path',
+    'base/path/',
+    'base/path',
+    '     base/path     ',
+])('%s as proxyBasePath should yield /base/path as base path', async (path) => {
     const config = createProxyConfig({
         unleashUrl: 'some',
         unleashApiToken: 'some',
         clientKeys: ['s1'],
-        proxyBasePath: path
+        proxyBasePath: path,
     });
 
     expect(config.proxyBasePath).toBe(`/base/path`);

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -368,12 +368,12 @@ test.each([
     'base/path/',
     'base/path',
     '     base/path     ',
-])('%s as proxyBasePath should yield /base/path as base path', async (path) => {
+])('%s as proxyBasePath should yield /base/path as base path', async (p) => {
     const config = createProxyConfig({
         unleashUrl: 'some',
         unleashApiToken: 'some',
         clientKeys: ['s1'],
-        proxyBasePath: path,
+        proxyBasePath: p,
     });
 
     expect(config.proxyBasePath).toBe(`/base/path`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -875,6 +875,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.23.tgz#3b41a6e643589ac6442bdbd7a4a3ded62f33f7da"
   integrity sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==
 
+"@types/node@18.7.14":
+  version "18.7.14"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.14.tgz#0fe081752a3333392d00586d815485a17c2cf3c9"
+  integrity sha512-6bbDaETVi8oyIARulOE9qF1/Qdi/23z6emrUh0fNJRUmjznqrixD4MpGDdgOFk5Xb0m2H6Xu42JGdvAxaJR/wA==
+
 "@types/prettier@^2.1.5":
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.4.tgz#5d9b63132df54d8909fce1c3f8ca260fdd693e17"


### PR DESCRIPTION
As requested in #76. The proxy should just be smart enough to format proxyBasePath to the format we expect (That is, leading slash and no trailing slash) This PR sanitizes when creating the config object.