### PR TITLE
Updated workflow to flag as prerelease

### DIFF
--- a/.github/workflows/release_changelog.yml
+++ b/.github/workflows/release_changelog.yml
@@ -22,5 +22,6 @@ jobs:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
           body: ${{ steps.github_release.outputs.changelog }}
+          prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'alpha') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
To avoid flagging alphas and betas as actual releases, 
this PR uses the prerelease flag when github.ref contains beta or alpha