### PR TITLE
feat: support regular evaluations via POST

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,3 +205,137 @@ The spec and UI can then be found at `<base url>/docs/openapi.json` and `<base u
 By default, the proxy only returns enabled toggles. However, in certain use cases, you might want it to return **all** toggles, regardless of whether they're enabled or disabled. The `/proxy/all` endpoint does this.
 
 Because returning all toggles regardless of their state is a potential security vulnerability, the endpoint has to be explicitly enabled. To enable it, set the `enableAllEndpoint` configuration option or the `ENABLE_ALL_ENDPOINT` environment variable to `true`.
+
+## POST API
+The proxy also offers a POST API used to evaluate toggles This can be used to evaluate a list of know toggle names or to retrieve all _enabled_ toggles for a given context. 
+
+### a) Evaluate list of known toggles
+
+This method will allow you to send a list of toggle names together with an Unleash Context and evaluate them accordingly. It will return enablement of all provided toggles. 
+
+**URL**: `POST https://proxy-host.server/proxy`
+
+**Content Type**: `application/json`
+
+**Body:**
+
+```json
+{
+	"toggles": ["demoApp.step1"],
+	"context": {
+		"appName": "someApp",
+		"sessionId": "233312AFF22",
+	}
+}
+```
+Result:
+
+```
+HTTP/1.1 200 OK
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: ETag
+Cache-control: public, max-age=2
+Connection: keep-alive
+Content-Length: 122
+Content-Type: application/json; charset=utf-8
+Date: Wed, 30 Nov 2022 14:46:48 GMT
+ETag: W/"7a-RMKUyY0BWIhjahpVPWnNdXyDw6I"
+Keep-Alive: timeout=5
+Vary: Accept-Encoding
+
+{
+    "toggles": [
+        {
+            "enabled": false,
+            "impressionData": true,
+            "name": "demoApp.step1",
+            "variant": {
+                "enabled": false,
+                "name": "disabled"
+            }
+        }
+    ]
+}
+
+```
+
+
+### a) Evaluate all enabled toggles
+
+This method will allow you to get all enabled toggles for a given context. 
+
+**URL**: `POST https://proxy-host.server/proxy`
+
+**Content Type**: `application/json`
+
+**Body:**
+
+```json
+{
+	"context": {
+		"appName": "someApp",
+		"sessionId": "233312AFF22",
+	}
+}
+```
+Result:
+
+```
+HTTP/1.1 200 OK
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: ETag
+Cache-control: public, max-age=2
+Connection: keep-alive
+Content-Length: 465
+Content-Type: application/json; charset=utf-8
+Date: Wed, 30 Nov 2022 14:48:55 GMT
+ETag: W/"1d1-dm6tkvMpkx42mZmojNSNKmHid1M"
+Keep-Alive: timeout=5
+Vary: Accept-Encoding
+
+{
+    "toggles": [
+        {
+            "enabled": true,
+            "impressionData": false,
+            "name": "demoApp.step2",
+            "variant": {
+                "enabled": true,
+                "name": "userWithId",
+                "payload": {
+                    "type": "string",
+                    "value": "90732934"
+                }
+            }
+        },
+        {
+            "enabled": true,
+            "impressionData": false,
+            "name": "demoApp.step3",
+            "variant": {
+                "enabled": true,
+                "name": "C",
+                "payload": {
+                    "type": "string",
+                    "value": "hello"
+                }
+            }
+        },
+        {
+            "enabled": true,
+            "impressionData": true,
+            "name": "demoApp.step4",
+            "variant": {
+                "enabled": true,
+                "name": "Orange",
+                "payload": {
+                    "type": "string",
+                    "value": "orange"
+                }
+            }
+        }
+    ]
+}
+
+
+```

--- a/example.js
+++ b/example.js
@@ -4,7 +4,8 @@ const { createApp } = require('./dist/app');
 
 const app = createApp({
     unleashUrl: 'https://app.unleash-hosted.com/demo/api/',
-    unleashApiToken: '56907a2fa53c1d16101d509a10b78e36190b0f918d9f122d',
+    unleashApiToken:
+        'demo-app:default.1d0fd3109556631d8e9469c75090f46f2ec269d094543890c9a81c4a',
     clientKeys: ['proxy-secret', 'another-proxy-secret', 's1'],
     refreshInterval: 1000,
     logLevel: 'trace',

--- a/src/test/unleash-proxy.test.ts
+++ b/src/test/unleash-proxy.test.ts
@@ -91,7 +91,7 @@ test('Should handle POST with empty/nonsensical body', async () => {
                 .expect(200)
                 .expect('Content-Type', /json/)
                 .then((response) => {
-                    expect(response.body.toggles).toHaveLength(0);
+                    expect(response.body.toggles).toHaveLength(2);
                 }),
         ),
     );
@@ -582,6 +582,28 @@ test('Should return all feature toggles', () => {
         .expect(200)
         .expect((res) => {
             expect(res.body.toggles.length).toBe(3);
+        });
+});
+
+test('Should return all enabled feature toggles when POST-ing', () => {
+    const client = new MockClient([
+        { name: 'a', enabled: true, impressionData: false },
+        { name: 'c', enabled: true, impressionData: true },
+    ]);
+
+    const proxySecrets = ['sdf'];
+    const app = createApp(
+        { unleashUrl, unleashApiToken, proxySecrets, enableAllEndpoint: true },
+        client,
+    );
+    client.emit('ready');
+
+    return request(app)
+        .post('/proxy')
+        .set('Authorization', 'sdf')
+        .expect(200)
+        .expect((res) => {
+            expect(res.body.toggles.length).toBe(2);
         });
 });
 

--- a/src/unleash-proxy.ts
+++ b/src/unleash-proxy.ts
@@ -1,5 +1,4 @@
 import { Request, Response, Router } from 'express';
-import { Context } from 'unleash-client';
 import { createContext } from './create-context';
 import { IProxyConfig } from './config';
 import { IClient } from './client';

--- a/src/unleash-proxy.ts
+++ b/src/unleash-proxy.ts
@@ -293,12 +293,20 @@ export default class UnleashProxy {
         } else {
             const { context = {}, toggles: toggleNames = [] } = req.body;
 
-            const toggles = this.client.getDefinedToggles(
-                toggleNames,
-                context as Context,
-            );
-
-            res.send({ toggles });
+            if (toggleNames.length > 0) {
+                const toggles = this.client.getDefinedToggles(
+                    toggleNames,
+                    context as Context,
+                );
+                res.set('Cache-control', 'public, max-age=2');
+                res.send({ toggles });
+            } else {
+                context.remoteAddress = context.remoteAddress || req.ip;
+                const actualContext = createContext(context);
+                const toggles = this.client.getEnabledToggles(actualContext);
+                res.set('Cache-control', 'public, max-age=2');
+                res.send({ toggles });
+            }
         }
     }
 

--- a/src/unleash-proxy.ts
+++ b/src/unleash-proxy.ts
@@ -291,20 +291,19 @@ export default class UnleashProxy {
         } else if (!clientToken || !this.clientKeys.includes(clientToken)) {
             res.sendStatus(401);
         } else {
+            res.set('Cache-control', 'public, max-age=2');
             const { context = {}, toggles: toggleNames = [] } = req.body;
+            const actualContext = createContext(context);
 
             if (toggleNames.length > 0) {
                 const toggles = this.client.getDefinedToggles(
                     toggleNames,
-                    context as Context,
+                    actualContext,
                 );
-                res.set('Cache-control', 'public, max-age=2');
                 res.send({ toggles });
             } else {
                 context.remoteAddress = context.remoteAddress || req.ip;
-                const actualContext = createContext(context);
                 const toggles = this.client.getEnabledToggles(actualContext);
-                res.set('Cache-control', 'public, max-age=2');
                 res.send({ toggles });
             }
         }


### PR DESCRIPTION
This PR extends the POST endpoint for fetching feature toggle configurations to also support empty list of feature toggle names, which basically makes POST work the same way as a regular GET request. 

```
POST https://url/proxy
body: {"context": "{"appName": "test"}}
```

Needed for https://github.com/Unleash/unleash-proxy-client-js/pull/125