### PR TITLE
fix: cleanup controller

### DIFF
--- a/src/context-middleware.ts
+++ b/src/context-middleware.ts
@@ -1,0 +1,24 @@
+import { NextFunction, Request, Response } from 'express';
+import { createContext } from './create-context';
+import { ContextEnricher, enrichContext } from './enrich-context';
+
+const POST = 'POST';
+const GET = 'GET';
+
+export const createContexMiddleware: Function =
+    (contextEnrichers: ContextEnricher[]) =>
+    async (req: Request, res: Response, next: NextFunction) => {
+        let context;
+        if (req.method === GET) {
+            context = req.query || {};
+        } else if (req.method === POST) {
+            context = req.body.context || {};
+        }
+        context.remoteAddress = context.remoteAddress || req.ip;
+        res.locals.context = await enrichContext(
+            contextEnrichers,
+            createContext(context),
+        );
+        next();
+        return;
+    };

--- a/src/context-middleware.ts
+++ b/src/context-middleware.ts
@@ -15,10 +15,14 @@ export const createContexMiddleware: Function =
             context = req.body.context || {};
         }
         context.remoteAddress = context.remoteAddress || req.ip;
-        res.locals.context = await enrichContext(
-            contextEnrichers,
-            createContext(context),
-        );
-        next();
+        try {
+            res.locals.context = await enrichContext(
+                contextEnrichers,
+                createContext(context),
+            );
+            next();
+        } catch (err) {
+            next(err); // or res.status(500).send("Failed to process the context");
+        }
         return;
     };

--- a/src/unleash-proxy.ts
+++ b/src/unleash-proxy.ts
@@ -287,7 +287,6 @@ If you don't provide the \`toggles\` property, then this operation functions exa
         } else if (!apiToken || !this.clientKeys.includes(apiToken)) {
             res.sendStatus(401);
         } else {
-            console.log('next!');
             next();
         }
     }

--- a/src/unleash-proxy.ts
+++ b/src/unleash-proxy.ts
@@ -1,8 +1,7 @@
 import { NextFunction, Request, Response, Router } from 'express';
-import { createContext } from './create-context';
 import { IProxyConfig } from './config';
 import { IClient } from './client';
-import { ContextEnricher, enrichContext } from './enrich-context';
+import { ContextEnricher } from './enrich-context';
 import { Logger } from './logger';
 import { OpenApiService } from './openapi/openapi-service';
 import { featuresResponse } from './openapi/spec/features-response';
@@ -21,7 +20,6 @@ import {
 import { RegisterMetricsSchema } from './openapi/spec/register-metrics-schema';
 import { LookupTogglesSchema } from './openapi/spec/lookup-toggles-schema';
 import { RegisterClientSchema } from './openapi/spec/register-client-schema';
-import { Context } from 'unleash-client';
 import { createContexMiddleware } from './context-middleware';
 
 export default class UnleashProxy {

--- a/src/unleash-proxy.ts
+++ b/src/unleash-proxy.ts
@@ -103,7 +103,7 @@ export default class UnleashProxy {
                 tags: ['Proxy client'],
             }),
             this.readyMiddleware.bind(this),
-            this.tokenMiddleware.bind(this),
+            this.clientTokenMiddleware.bind(this),
             contextMiddleware,
             this.getEnabledToggles.bind(this),
         );
@@ -141,7 +141,7 @@ However, using this endpoint will increase the payload size transmitted to your 
                 tags: ['Proxy client'],
             }),
             this.readyMiddleware.bind(this),
-            this.tokenMiddleware.bind(this),
+            this.clientTokenMiddleware.bind(this),
             contextMiddleware,
             this.getAllToggles.bind(this),
         );
@@ -164,7 +164,7 @@ If you don't provide the \`toggles\` property, then this operation functions exa
                 tags: ['Proxy client'],
             }),
             this.readyMiddleware.bind(this),
-            this.tokenMiddleware.bind(this),
+            this.clientTokenMiddleware.bind(this),
             contextMiddleware,
             this.getAllTogglesPOST.bind(this),
         );
@@ -187,7 +187,7 @@ If you don't provide the \`toggles\` property, then this operation functions exa
                 tags: ['Proxy client'],
             }),
             this.readyMiddleware.bind(this),
-            this.tokenMiddleware.bind(this),
+            this.clientTokenMiddleware.bind(this),
             contextMiddleware,
             this.lookupToggles.bind(this),
         );
@@ -206,7 +206,7 @@ If you don't provide the \`toggles\` property, then this operation functions exa
                 tags: ['Server-side client'],
             }),
             this.readyMiddleware.bind(this),
-            this.tokenMiddleware.bind(this),
+            this.clientTokenMiddleware.bind(this),
             this.unleashApi.bind(this),
         );
 
@@ -295,7 +295,11 @@ If you don't provide the \`toggles\` property, then this operation functions exa
         }
     }
 
-    private tokenMiddleware(req: Request, res: Response, next: NextFunction) {
+    private clientTokenMiddleware(
+        req: Request,
+        res: Response,
+        next: NextFunction,
+    ) {
         const apiToken = req.header(this.clientKeysHeaderName);
         if (!apiToken || !this.clientKeys.includes(apiToken)) {
             res.sendStatus(401);


### PR DESCRIPTION
This cleanup aims to reduce duplication in the main controller of the proxy by using middlewares for two things:

1. Validate proxy is ready to handle requests
2. Resolve the context (and enrich it with custom enrichers)


/cc @LukasHeimann 