### PR TITLE
Add `metricsStartJitter` option to proxy config

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -112,8 +112,8 @@ class Client extends EventEmitter implements IClient {
             this.emit('ready');
             this.ready = true;
             if (config.metricsStartJitter) {
-                const delay = Math.floor(Math.random() * config.metricsStartJitter)
-                setTimeout(() => this.metrics.start(), delay)
+                const delay = Math.floor(Math.random() * config.metricsStartJitter);
+                setTimeout(() => this.metrics.start(), delay);
             } else {
                 this.metrics.start();
             }

--- a/src/client.ts
+++ b/src/client.ts
@@ -111,7 +111,12 @@ class Client extends EventEmitter implements IClient {
         this.unleash.on('ready', () => {
             this.emit('ready');
             this.ready = true;
-            this.metrics.start();
+            if (config.metricsStartJitter) {
+                const delay = Math.floor(Math.random() * config.metricsStartJitter)
+                setTimeout(() => this.metrics.start(), delay)
+            } else {
+                this.metrics.start();
+            }
         });
     }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,7 @@ export interface IProxyOption {
     proxyBasePath?: string;
     refreshInterval?: number;
     metricsInterval?: number;
+    metricsStartJitter?: number;
     environment?: string;
     projectName?: string;
     logger?: Logger;
@@ -53,6 +54,7 @@ export interface IProxyConfig {
     proxyBasePath: string;
     refreshInterval: number;
     metricsInterval: number;
+    metricsStartJitter: number;
     environment?: string;
     projectName?: string;
     logger: Logger;
@@ -328,6 +330,9 @@ export function createProxyConfig(option: IProxyOption): IProxyConfig {
         metricsInterval:
             option.metricsInterval ||
             safeNumber(process.env.UNLEASH_METRICS_INTERVAL, 30_000),
+        metricsStartJitter:
+            option.metricsStartJitter ||
+            safeNumber(process.env.UNLEASH_METRICS_START_JITTER, 0),
         environment: option.environment || process.env.UNLEASH_ENVIRONMENT,
         projectName: option.projectName || process.env.UNLEASH_PROJECT_NAME,
         namePrefix: option.namePrefix || process.env.UNLEASH_NAME_PREFIX,


### PR DESCRIPTION
## About the changes
Adds a metricsStartJitter option to the IProxyOptions and IProxyConfig interfaces, and uses this jitter to start metrics with a random setTimeout, if its value is greater than zero.

## Discussion points
This only adds jitter to the initial startup delay when sending metrics. This should be sufficient to prevent most spikes in metrics traffic from a fleet of proxies. We may need to consider adding jitter to each metrics request in the node client, and pass through a setting from the proxy config.
