### PR TITLE
docs: fix endpoint description POST /proxy

### DIFF
--- a/src/test/__snapshots__/openapi.test.ts.snap
+++ b/src/test/__snapshots__/openapi.test.ts.snap
@@ -669,7 +669,7 @@ Object {
         ],
       },
       "post": Object {
-        "description": "This endpoint accepts a JSON object with \`context\` and \`toggles\` properties. The Proxy will use the provided context values and evaluate the toggles provided in the \`toggle\` property. It returns the toggles that evaluate to false. As such, the list it returns is always a subset of the toggles you provide it.",
+        "description": "This endpoint accepts a JSON object with \`context\` and \`toggles\` properties. The Proxy will use the provided context values and evaluate the toggles provided in the \`toggles\` property. The list it returns always contains all the toggles you provide it with.",
         "requestBody": Object {
           "content": Object {
             "application/json": Object {

--- a/src/unleash-proxy.ts
+++ b/src/unleash-proxy.ts
@@ -162,7 +162,7 @@ export default class UnleashProxy {
                     200: featuresResponse,
                 },
                 description:
-                    'This endpoint accepts a JSON object with `context` and `toggles` properties. The Proxy will use the provided context values and evaluate the toggles provided in the `toggle` property. It returns the toggles that evaluate to false. As such, the list it returns is always a subset of the toggles you provide it.',
+                    'This endpoint accepts a JSON object with `context` and `toggles` properties. The Proxy will use the provided context values and evaluate the toggles provided in the `toggles` property. The list it returns always contains all the toggles you provide it with.',
                 summary:
                     'Which of the provided toggles are enabled given the provided context?',
                 tags: ['Proxy client'],


### PR DESCRIPTION
## What

This change updates the operation description for the `POST /proxy` operation. It changes it from implying that only some toggles are returned to explicitly saying that all toggles are returned.

## Why

The original description was misleading. Probably because the author (me 🙋) didn't quite understand how the endpoint worked when they wrote it.