### PR TITLE
fix: move required content type check

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -45,10 +45,9 @@ export function createApp(
 
     app.use(compression());
 
-    app.use(requireContentType());
-
     app.use(
         `${config.proxyBasePath}/proxy`,
+        requireContentType(),
         cors(corsOptions),
         express.json(),
         proxy.middleware,


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
Solves problem introduced in https://github.com/Unleash/unleash-proxy/pull/119
If application in general supports other content types (file upload for example) then now it doesn't. Moving required types checking to proxy endpoints resolves problem/limitation

<!-- Does it close an issue? Multiple? -->
<!-- Closes # -->

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

<!-- ### Important files -->
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


<!-- ## Discussion points -->
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
