### PR TITLE
fix: define region to ensure we login to us-east-1 for public

### DIFF
--- a/.github/workflows/push-ecr-releases.yml
+++ b/.github/workflows/push-ecr-releases.yml
@@ -16,6 +16,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1
         with:
           registry-type: public
+          aws-region: 'us-east-1'
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3


### PR DESCRIPTION
So. ecr-public can only be logged in to from us-east-1, so this PR sets the region of the login task to be us-east-1. This is part of publishing unleash-proxy to AWS ECR public.