### PR TITLE
Release v0.15.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unleash/proxy",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "The Unleash Proxy (Open-Source)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This PR releases v0.15.2. It contains a bugfix (#126) for the recently released content-type checking that the proxy does.

## The content-type bug

Prior to this fix, the content-type checking would apply to all endpoints on the app you use for the proxy. If you use the proxy as a standalone app, then that doesn't really matter, but if you pass in a separate app, then all non-proxy endpoints will also have the content-type checking applied.

The fix, provided by @Dzixxx, makes it so that the content-type validation only happens on the endpoints bundled by the proxy.