### PR TITLE
fix: make the swagger UI work correctly when using PROXY_BASE_PATH

### DIFF
--- a/src/openapi/index.ts
+++ b/src/openapi/index.ts
@@ -10,11 +10,10 @@ import { variantSchema } from './spec/variant-schema';
 
 // Create the base OpenAPI schema, with everything except paths.
 export const createOpenApiSchema = (
-    serverUrl?: string,
     clientKeysHeaderName: string = 'Authorization',
 ): Omit<OpenAPIV3.Document, 'paths'> => ({
     openapi: '3.0.3',
-    servers: serverUrl ? [{ url: serverUrl }] : [],
+    servers: [],
     info: {
         title: 'Unleash Proxy API',
         version: process.env.npm_package_version || '',

--- a/src/openapi/openapi-service.ts
+++ b/src/openapi/openapi-service.ts
@@ -14,10 +14,7 @@ export class OpenApiService {
         this.config = config;
         this.api = openapi(
             this.docsPath(),
-            createOpenApiSchema(
-                config.proxyBasePath,
-                config.clientKeysHeaderName,
-            ),
+            createOpenApiSchema(config.clientKeysHeaderName),
             { coerce: true },
         );
     }


### PR DESCRIPTION
This PR changes the `server` property of the OpenAPI spec that we serve to make it work when you provide a proxy base path.

The way we have the spec set up, we'll only ever have a single server, so there's no point in providing the base url the way we used to. According to the [OpenAPI spec](https://swagger.io/docs/specification/api-host-and-base-path/), an empty list will make it fall back to the default, which is `/`.

The only difference you'll see in the UI from before is that the servers dropdown is gone.

![image](https://github.com/Unleash/unleash-proxy/assets/17786332/1a419b52-b73c-4174-b8d6-a6335d1aca38)

## Discussion

Ideally, I think we would like the `/base/path` to be part of the server base path and not a prefix to each and every API endpoint. However, as we have seen in Unleash (https://github.com/Unleash/unleash/pull/2079), that isn't trivial.

This PR should fix the problem for now. If we want to, we can make the improvement later.

closes #125