### PR TITLE
Update Node version in Dockerfile: v14 -> v18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine as builder
+FROM node:18-alpine as builder
 
 WORKDIR /unleash-proxy
 
@@ -10,7 +10,7 @@ RUN yarn build
 
 RUN yarn install --production  --frozen-lockfile --ignore-scripts --prefer-offline
 
-FROM node:14-alpine
+FROM node:18-alpine
 
 ENV NODE_ENV production
 


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

This updates Node in the Dockerfile from v14 to v18, as v14 reached EOL on April 30th 2023.

v18 was selected as it is now the minimum version supported by Unleash v5.

<!-- Does it close an issue? Multiple? -->

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->