### PR TITLE
fix: force get variant uses strategy variants

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unleash/proxy",
-  "version": "0.17.0-beta.1",
+  "version": "0.17.0-beta.2",
   "description": "The Unleash Proxy (Open-Source)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -45,7 +45,7 @@
     "json-schema-to-ts": "^2.3.0",
     "openapi-types": "^11.0.0",
     "type-is": "^1.6.18",
-    "unleash-client": "^4.1.0-beta.2"
+    "unleash-client": "^4.1.0-beta.3"
   },
   "devDependencies": {
     "@apidevtools/swagger-parser": "10.1.0",

--- a/src/client.ts
+++ b/src/client.ts
@@ -102,7 +102,7 @@ class Client extends EventEmitter implements IClient {
         return definitions.map((d) => {
             const enabled = this.unleash.isEnabled(d.name, context);
             const variant = enabled
-                ? this.unleash.getVariant(d.name, context)
+                ? this.unleash.forceGetVariant(d.name, context)
                 : getDefaultVariant();
 
             return {
@@ -127,7 +127,7 @@ class Client extends EventEmitter implements IClient {
             .map((d) => ({
                 name: d.name,
                 enabled: true,
-                variant: this.unleash.getVariant(d.name, context),
+                variant: this.unleash.forceGetVariant(d.name, context),
                 impressionData: d.impressionData,
             }));
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4608,10 +4608,10 @@ unique-slug@^3.0.0:
   dependencies:
     imurmurhash "^0.1.4"
 
-unleash-client@^4.1.0-beta.2:
-  version "4.1.0-beta.2"
-  resolved "https://registry.yarnpkg.com/unleash-client/-/unleash-client-4.1.0-beta.2.tgz#e96450a71bb4851f9c1bf81589f7aa611725e42e"
-  integrity sha512-1xh3JaM1jWsLSqLJY4Yt0S2/iVwhH4XTB1zYCKune5JfCxnJQXn4pSFJrVr5Vu2TjlGOXFQiF8uDc98QvzNJqw==
+unleash-client@^4.1.0-beta.3:
+  version "4.1.0-beta.3"
+  resolved "https://registry.yarnpkg.com/unleash-client/-/unleash-client-4.1.0-beta.3.tgz#8d512daa3ca8bfc420de8337eafcf7db71a864d6"
+  integrity sha512-t6DbImuxTK9gtkzBy826aQd549M/GAxCMGHOEwDGR6SOQF2UCs10s7GUnlSVG5TM4QDRdphz2snxoVGpzKuROw==
   dependencies:
     ip "^1.1.8"
     make-fetch-happen "^10.2.1"


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

forceGetVariant in node is fixed now so we can use it. We can use strategy variants without emitting impression events inside the proxy. Events emission should be done in the frontend SDKs

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
