### PR TITLE
feat: add frontend alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Single page apps work in the context of a specific user. The proxy allows you to
 
 ## API
 
-The Unleash proxy exposes a simple API for consumption by client-side SDKs.
+The Unleash proxy exposes a simple API for consumption by client-side SDKs. As of `v0.17.1`, you can use `/frontend` and `/proxy` interchangeably.
 
 ### OpenAPI integration
 
@@ -51,18 +51,18 @@ The spec and UI can then be found at `<base url>/docs/openapi.json` and `<base u
 
 You can refer to the [how to enable the OpenAPI spec](https://docs.getunleash.io/how-to/how-to-enable-openapi) guide for more detailed information on how to configure it.
 
-### `GET /proxy`
+### `GET /frontend`
 
 The primary proxy API operation. This endpoint accepts an Unleash context encoded as query parameters, and will return all toggles that are evaluated as true for the provided context.
 
 <figure>
     <img src="./.github/img/get-request.png" />
-    <figcaption>When sending GET requests to the Unleash proxy's /proxy endpoint, the request should contain the current Unleash context as query parameters. The proxy will return all enabled toggles for the provided context.</figcaption>
+    <figcaption>When sending GET requests to the Unleash proxy's /frontend endpoint, the request should contain the current Unleash context as query parameters. The proxy will return all enabled toggles for the provided context.</figcaption>
 </figure>
 
 ### Payload
 
-The `GET /proxy` operation returns information about toggles enabled for the current user. The payload is a JSON object with a `toggles` property, which contains a list of toggles.
+The `GET /frontend` operation returns information about toggles enabled for the current user. The payload is a JSON object with a `toggles` property, which contains a list of toggles.
 
 ```json
 {
@@ -174,7 +174,7 @@ The `value` will always be the payload's content as a string, escaped as necessa
 }
 ```
 
-### `POST /proxy`
+### `POST /frontend`
 
 The proxy also offers a POST API used to evaluate toggles This can be used to evaluate a list of know toggle names or to retrieve all _enabled_ toggles for a given context.
 
@@ -182,7 +182,7 @@ The proxy also offers a POST API used to evaluate toggles This can be used to ev
 
 This method will allow you to send a list of toggle names together with an Unleash Context and evaluate them accordingly. It will return enablement of all provided toggles.
 
-**URL**: `POST https://proxy-host.server/proxy`
+**URL**: `POST https://proxy-host.server/frontend`
 
 **Content Type**: `application/json`
 
@@ -233,7 +233,7 @@ Vary: Accept-Encoding
 
 This method will allow you to get all enabled toggles for a given context.
 
-**URL**: `POST https://proxy-host.server/proxy`
+**URL**: `POST https://proxy-host.server/frontend`
 
 **Content Type**: `application/json`
 
@@ -310,20 +310,20 @@ Vary: Accept-Encoding
 
 ```
 
-### `GET /proxy/all` Return enabled **and** disabled toggles:
+### `GET /frontend/all` Return enabled **and** disabled toggles:
 
-By default, the proxy only returns enabled toggles. However, in certain use cases, you might want it to return **all** toggles, regardless of whether they're enabled or disabled. The `/proxy/all` endpoint does this.
+By default, the proxy only returns enabled toggles. However, in certain use cases, you might want it to return **all** toggles, regardless of whether they're enabled or disabled. The `/frontend/all` endpoint does this.
 
 Because returning all toggles regardless of their state is a potential security vulnerability, the endpoint has to be explicitly enabled. To enable it, set the `enableAllEndpoint` configuration option or the `ENABLE_ALL_ENDPOINT` environment variable to `true`.
 
-The response payload follows the same format as the [`GET /proxy` response payload](#payload).
+The response payload follows the same format as the [`GET /frontend` response payload](#payload).
 
-### `GET /proxy/health`: Health endpoint
+### `GET /frontend/health`: Health endpoint
 
 The proxy will try to synchronize with the Unleash API at startup, until it has successfully done that the proxy will return `HTTP 503 - Not Ready` for all request. You can use the health endpoint to validate that the proxy is ready to receive requests:
 
 ```bash
-curl http://localhost:3000/proxy/health -I
+curl http://localhost:3000/frontend/health -I
 ```
 
 If the proxy is ready, the response should look a little something like this:
@@ -365,7 +365,7 @@ You **must configure** these three variables for the proxy to start successfully
 | clientKeys | `UNLEASH_PROXY_CLIENT_KEYS` | n/a | yes | List of client keys that the proxy should accept. When querying the proxy, Proxy SDKs must set the request's _client keys header_ to one of these values. The default client keys header is `Authorization`. |
 | proxySecrets | `UNLEASH_PROXY_SECRETS` | n/a | no | Deprecated alias for `clientKeys`. Please use `clientKeys` instead. |
 | n/a | `PORT` or `PROXY_PORT` | 3000 | no | The port where the proxy should listen. |
-| proxyBasePath | `PROXY_BASE_PATH` | "" | no | The base path to run the proxy from. "/proxy" will be added at the end. For instance, if `proxyBasePath` is `"base/path"`, the proxy will run at `/base/path/proxy`. |
+| proxyBasePath | `PROXY_BASE_PATH` | "" | no | The base path to run the proxy from. "/frontend" will be added at the end. For instance, if `proxyBasePath` is `"base/path"`, the proxy will run at `/base/path/frontend`. |
 | unleashAppName | `UNLEASH_APP_NAME` | "unleash-proxy" | no | App name to used when registering with Unleash |
 | unleashInstanceId | `UNLEASH_INSTANCE_ID` | `generated` | no | Unleash instance id to used when registering with Unleash |
 | refreshInterval | `UNLEASH_FETCH_INTERVAL` | 5000 | no | How often the proxy should query Unleash for updates, defined in ms. |
@@ -383,7 +383,7 @@ You **must configure** these three variables for the proxy to start successfully
 | clientKeysHeaderName | `CLIENT_KEY_HEADER_NAME` | "authorization" | no | The name of the HTTP header to use for client keys. Incoming requests must set the value of this header to one of the Proxy's `clientKeys` to be authorized successfully. |
 | storageProvider | n/a | `undefined` | no | Register a custom storage provider. Refer to the [section on custom storage providers in the Node.js SDK's readme](https://github.com/Unleash/unleash-client-node/#custom-store-provider) for more information. |
 | enableOAS | `ENABLE_OAS` | `false` | no | Set to `true` to expose the proxy's OpenAPI spec at `/docs/openapi.json` and an interactive OpenAPI UI at `/docs/openapi`. Read more in the [OpenAPI section](#openapi). |
-| enableAllEndpoint | `ENABLE_ALL_ENDPOINT` | `false` | no | Set to `true` to expose the `/proxy/all` endpoint. Refer to the [section on returning all toggles](#return-enabled-and-disabled-toggles) for more info. |
+| enableAllEndpoint | `ENABLE_ALL_ENDPOINT` | `false` | no | Set to `true` to expose the `/frontend/all` endpoint. Refer to the [section on returning all toggles](#return-enabled-and-disabled-toggles) for more info. |
 | cors | n/a | n/a | no | Pass custom options for [CORS module](https://www.npmjs.com/package/cors#configuration-options) |
 | cors.allowedHeaders | `CORS_ALLOWED_HEADERS` | n/a | no | Headers to allow for CORS |
 | cors.credentials | `CORS_CREDENTIALS` | `false` | no | Allow credentials in CORS requests |
@@ -456,7 +456,7 @@ Unleash-proxy is listening on port 3000!
 In order to verify the proxy you can use curl and see that you get a few evaluated feature toggles back:
 
 ```bash
-curl http://localhost:3000/proxy -H "Authorization: some-secret"
+curl http://localhost:3000/frontend -H "Authorization: some-secret"
 ```
 
 Expected output would be something like:
@@ -489,7 +489,7 @@ Expected output would be something like:
 The proxy will try to synchronize with the Unleash API at startup, until it has successfully done that the proxy will return `HTTP 503 - Not Read?` for all request. You can use the health endpoint to validate that the proxy is ready to recieve requests:
 
 ```bash
-curl http://localhost:3000/proxy/health -I
+curl http://localhost:3000/frontend/health -I
 ```
 
 ```bash
@@ -531,7 +531,7 @@ const app = createApp({
 
 app.listen(port, () =>
   // eslint-disable-next-line no-console
-  console.log(`Unleash Proxy listening on http://localhost:${port}/proxy`),
+  console.log(`Unleash Proxy listening on http://localhost:${port}/frontend`),
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 The Unleash proxy offers a way to use Unleash in client-side applications, such as single-page and native apps.
 
+> **Note:** You might want to consider using [Unleash Edge](https://www.unleash-hosted.com/edge) instead.
+
 The Unleash proxy sits between the Unleash API and your client-side SDK and does the evaluation of feature toggles for your client-side SDK. This way, you can keep your configuration private and secure, while still allowing your client-side apps to use Unleash's features.
 
 The proxy offers three important features:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unleash/proxy",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "The Unleash Proxy (Open-Source)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/app.ts
+++ b/src/app.ts
@@ -50,13 +50,16 @@ export function createApp(
 
     app.use(compression());
 
-    app.use(
-        [`${config.proxyBasePath}/proxy`, `${config.proxyBasePath}/frontend`],
+    const proxyMiddleware = [
         requireContentType(),
         cors(corsOptions),
         express.json(),
         proxy.middleware,
-    );
+    ];
+
+    app.use(`${config.proxyBasePath}/proxy`, proxyMiddleware);
+    app.use(`${config.proxyBasePath}/frontend`, proxyMiddleware);
+
     openApiService.useErrorHandler(app);
     return app;
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -51,7 +51,7 @@ export function createApp(
     app.use(compression());
 
     app.use(
-        `${config.proxyBasePath}/proxy`,
+        [`${config.proxyBasePath}/proxy`, `${config.proxyBasePath}/frontend`],
         requireContentType(),
         cors(corsOptions),
         express.json(),

--- a/src/test/__snapshots__/openapi.test.ts.snap
+++ b/src/test/__snapshots__/openapi.test.ts.snap
@@ -608,6 +608,705 @@ Object {
   },
   "openapi": "3.0.3",
   "paths": Object {
+    "/frontend": Object {
+      "get": Object {
+        "description": "This endpoint returns the list of feature toggles that the proxy evaluates to enabled for the given context. Context values are provided as query parameters.",
+        "parameters": Array [
+          Object {
+            "description": "Your application's name",
+            "in": "query",
+            "name": "appName",
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "description": "The current user's ID",
+            "in": "query",
+            "name": "userId",
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "description": "The current session's ID",
+            "in": "query",
+            "name": "sessionId",
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "description": "Your application's IP address",
+            "in": "query",
+            "name": "remoteAddress",
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "description": "Additional (custom) context fields",
+            "example": Object {
+              "betaTester": "true",
+              "region": "Africa",
+            },
+            "explode": true,
+            "in": "query",
+            "name": "properties",
+            "schema": Object {
+              "type": "object",
+            },
+            "style": "form",
+          },
+        ],
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "$ref": "#/components/schemas/featuresSchema",
+                },
+              },
+            },
+            "description": "The list of enabled toggles for the provided context.",
+          },
+          "401": Object {
+            "description": "Authorization information is missing or invalid.",
+          },
+          "500": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "example": Object {
+                    "error": "Whoops! We dropped the ball on this one (an unexpected error occurred): Cannot read properties of undefined (reading 'includes')",
+                  },
+                  "properties": Object {
+                    "error": Object {
+                      "type": "string",
+                    },
+                  },
+                  "required": Array [
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Something went wrong on the server side and we were unable to recover. If you have custom strategies loaded, make sure they don't throw errors.",
+          },
+          "503": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "example": "The Unleash Proxy has not connected to the Unleash API and is not ready to accept requests yet.",
+                  "type": "string",
+                },
+              },
+            },
+            "description": "The proxy isn't ready to accept requests yet.",
+          },
+        },
+        "summary": "Retrieve enabled feature toggles for the provided context.",
+        "tags": Array [
+          "Proxy client",
+        ],
+      },
+      "post": Object {
+        "description": "This endpoint accepts a JSON object with a \`context\` property and an optional \`toggles\` property.
+
+If you provide the \`toggles\` property, the proxy will use the provided context value to evaluate each of the toggles you sent in. The proxy returns a list with all the toggles you provided in their fully evaluated states.
+
+If you don't provide the \`toggles\` property, then this operation functions exactly the same as the GET operation on this endpoint, except that it uses the \`context\` property instead of query parameters: The proxy will evaluate all its toggles against the context you provide and return a list of enabled toggles.",
+        "requestBody": Object {
+          "content": Object {
+            "application/json": Object {
+              "schema": Object {
+                "$ref": "#/components/schemas/lookupTogglesSchema",
+              },
+            },
+          },
+        },
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "$ref": "#/components/schemas/featuresSchema",
+                },
+              },
+            },
+            "description": "The list of enabled toggles for the provided context.",
+          },
+          "400": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "example": Object {
+                    "error": "Request validation failed",
+                    "validation": Array [
+                      Object {
+                        "dataPath": ".body",
+                        "keyword": "required",
+                        "message": "should have required property 'appName'",
+                        "params": Object {
+                          "missingProperty": "appName",
+                        },
+                        "schemaPath": "#/components/schemas/registerMetricsSchema/required",
+                      },
+                    ],
+                  },
+                  "properties": Object {
+                    "error": Object {
+                      "type": "string",
+                    },
+                    "validation": Object {
+                      "items": Object {
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": Array [
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The provided request data is invalid.",
+          },
+          "401": Object {
+            "description": "Authorization information is missing or invalid.",
+          },
+          "415": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "example": "Unsupported media type",
+                  "type": "string",
+                },
+              },
+            },
+            "description": "The operation does not support request payloads of the provided type.",
+          },
+          "500": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "example": Object {
+                    "error": "Whoops! We dropped the ball on this one (an unexpected error occurred): Cannot read properties of undefined (reading 'includes')",
+                  },
+                  "properties": Object {
+                    "error": Object {
+                      "type": "string",
+                    },
+                  },
+                  "required": Array [
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Something went wrong on the server side and we were unable to recover. If you have custom strategies loaded, make sure they don't throw errors.",
+          },
+          "503": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "example": "The Unleash Proxy has not connected to the Unleash API and is not ready to accept requests yet.",
+                  "type": "string",
+                },
+              },
+            },
+            "description": "The proxy isn't ready to accept requests yet.",
+          },
+        },
+        "summary": "Evaluate specific toggles against the provided context.",
+        "tags": Array [
+          "Proxy client",
+        ],
+      },
+    },
+    "/frontend/all": Object {
+      "get": Object {
+        "description": "This endpoint returns all feature toggles known to the proxy, along with whether they are enabled or disabled for the provided context. This endpoint always returns **all** feature toggles the proxy retrieves from Unleash, in contrast to the \`/frontend\` endpoints that only return enabled toggles.
+
+Useful if you are migrating to unleash and need to know if the feature flag exists on the Unleash server.
+
+However, using this endpoint will increase the payload size transmitted to your applications. Context values are provided as query parameters.",
+        "parameters": Array [
+          Object {
+            "description": "Your application's name",
+            "in": "query",
+            "name": "appName",
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "description": "The current user's ID",
+            "in": "query",
+            "name": "userId",
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "description": "The current session's ID",
+            "in": "query",
+            "name": "sessionId",
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "description": "Your application's IP address",
+            "in": "query",
+            "name": "remoteAddress",
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "description": "Additional (custom) context fields",
+            "example": Object {
+              "betaTester": "true",
+              "region": "Africa",
+            },
+            "explode": true,
+            "in": "query",
+            "name": "properties",
+            "schema": Object {
+              "type": "object",
+            },
+            "style": "form",
+          },
+        ],
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "$ref": "#/components/schemas/featuresSchema",
+                },
+              },
+            },
+            "description": "The list of enabled toggles for the provided context.",
+          },
+          "401": Object {
+            "description": "Authorization information is missing or invalid.",
+          },
+          "500": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "example": Object {
+                    "error": "Whoops! We dropped the ball on this one (an unexpected error occurred): Cannot read properties of undefined (reading 'includes')",
+                  },
+                  "properties": Object {
+                    "error": Object {
+                      "type": "string",
+                    },
+                  },
+                  "required": Array [
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Something went wrong on the server side and we were unable to recover. If you have custom strategies loaded, make sure they don't throw errors.",
+          },
+          "501": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "example": Object {
+                    "error": "This functionality is not implemented by the server",
+                  },
+                  "properties": Object {
+                    "error": Object {
+                      "description": "A description of the error that occurred.",
+                      "type": "string",
+                    },
+                  },
+                  "required": Array [
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The functionality you are requesting is not implemented by the server. This could be due to a misconfiguration when starting the server.",
+          },
+          "503": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "example": "The Unleash Proxy has not connected to the Unleash API and is not ready to accept requests yet.",
+                  "type": "string",
+                },
+              },
+            },
+            "description": "The proxy isn't ready to accept requests yet.",
+          },
+        },
+        "summary": "Retrieve all feature toggles from the proxy.",
+        "tags": Array [
+          "Proxy client",
+        ],
+      },
+      "post": Object {
+        "description": "This endpoint accepts a JSON object with a \`context\` property and an optional \`toggles\` property.
+
+If you provide the \`toggles\` property, the proxy will use the provided context value to evaluate each of the toggles you sent in. The proxy returns a list with all the toggles you provided in their fully evaluated states.
+
+If you don't provide the \`toggles\` property, then this operation functions exactly the same as the GET operation on this endpoint, except that it uses the \`context\` property instead of query parameters: The proxy will evaluate all its toggles against the context you provide and return a list of all known feature toggles and their evaluated state.",
+        "requestBody": Object {
+          "content": Object {
+            "application/json": Object {
+              "schema": Object {
+                "$ref": "#/components/schemas/lookupTogglesSchema",
+              },
+            },
+          },
+        },
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "$ref": "#/components/schemas/featuresSchema",
+                },
+              },
+            },
+            "description": "The list of enabled toggles for the provided context.",
+          },
+          "401": Object {
+            "description": "Authorization information is missing or invalid.",
+          },
+          "415": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "example": "Unsupported media type",
+                  "type": "string",
+                },
+              },
+            },
+            "description": "The operation does not support request payloads of the provided type.",
+          },
+          "500": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "example": Object {
+                    "error": "Whoops! We dropped the ball on this one (an unexpected error occurred): Cannot read properties of undefined (reading 'includes')",
+                  },
+                  "properties": Object {
+                    "error": Object {
+                      "type": "string",
+                    },
+                  },
+                  "required": Array [
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Something went wrong on the server side and we were unable to recover. If you have custom strategies loaded, make sure they don't throw errors.",
+          },
+          "501": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "example": Object {
+                    "error": "This functionality is not implemented by the server",
+                  },
+                  "properties": Object {
+                    "error": Object {
+                      "description": "A description of the error that occurred.",
+                      "type": "string",
+                    },
+                  },
+                  "required": Array [
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The functionality you are requesting is not implemented by the server. This could be due to a misconfiguration when starting the server.",
+          },
+          "503": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "example": "The Unleash Proxy has not connected to the Unleash API and is not ready to accept requests yet.",
+                  "type": "string",
+                },
+              },
+            },
+            "description": "The proxy isn't ready to accept requests yet.",
+          },
+        },
+        "summary": "Evaluate some or all toggles against the provided context.",
+        "tags": Array [
+          "Proxy client",
+        ],
+      },
+    },
+    "/frontend/client/features": Object {
+      "get": Object {
+        "description": "Returns the toggle configuration from the proxy's internal Unleash SDK. Use this to bootstrap other proxies and server-side SDKs. Requires you to provide one of the proxy's configured \`serverSideTokens\` for authorization.",
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "$ref": "#/components/schemas/apiRequestSchema",
+                },
+              },
+            },
+            "description": "The proxy's current feature toggle configuration. A list of feature toggles that is parseable by other server-side clients.",
+          },
+          "401": Object {
+            "description": "Authorization information is missing or invalid.",
+          },
+          "503": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "example": "The Unleash Proxy has not connected to the Unleash API and is not ready to accept requests yet.",
+                  "type": "string",
+                },
+              },
+            },
+            "description": "The proxy isn't ready to accept requests yet.",
+          },
+        },
+        "summary": "Retrieve the proxy's current toggle configuration (as consumed by the internal client).",
+        "tags": Array [
+          "Server-side client",
+        ],
+      },
+    },
+    "/frontend/client/metrics": Object {
+      "post": Object {
+        "description": "This endpoint lets you register usage metrics with Unleash. Accepts either one of the proxy's configured \`serverSideTokens\` or one of its \`clientKeys\` for authorization.",
+        "requestBody": Object {
+          "content": Object {
+            "application/json": Object {
+              "schema": Object {
+                "$ref": "#/components/schemas/registerMetricsSchema",
+              },
+            },
+          },
+        },
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "example": "ok",
+                  "type": "string",
+                },
+              },
+            },
+            "description": "The request was successful.",
+          },
+          "400": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "example": Object {
+                    "error": "Request validation failed",
+                    "validation": Array [
+                      Object {
+                        "dataPath": ".body",
+                        "keyword": "required",
+                        "message": "should have required property 'appName'",
+                        "params": Object {
+                          "missingProperty": "appName",
+                        },
+                        "schemaPath": "#/components/schemas/registerMetricsSchema/required",
+                      },
+                    ],
+                  },
+                  "properties": Object {
+                    "error": Object {
+                      "type": "string",
+                    },
+                    "validation": Object {
+                      "items": Object {
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": Array [
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The provided request data is invalid.",
+          },
+          "401": Object {
+            "description": "Authorization information is missing or invalid.",
+          },
+        },
+        "summary": "Send usage metrics to Unleash.",
+        "tags": Array [
+          "Operational",
+          "Server-side client",
+        ],
+      },
+    },
+    "/frontend/client/register": Object {
+      "post": Object {
+        "description": "This endpoint lets you register application with Unleash. Accepts either one of the proxy's configured \`serverSideTokens\` or one of its \`clientKeys\` for authorization.",
+        "requestBody": Object {
+          "content": Object {
+            "application/json": Object {
+              "schema": Object {
+                "$ref": "#/components/schemas/registerClientSchema",
+              },
+            },
+          },
+        },
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "example": "ok",
+                  "type": "string",
+                },
+              },
+            },
+            "description": "The request was successful.",
+          },
+          "400": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "example": Object {
+                    "error": "Request validation failed",
+                    "validation": Array [
+                      Object {
+                        "dataPath": ".body",
+                        "keyword": "required",
+                        "message": "should have required property 'appName'",
+                        "params": Object {
+                          "missingProperty": "appName",
+                        },
+                        "schemaPath": "#/components/schemas/registerMetricsSchema/required",
+                      },
+                    ],
+                  },
+                  "properties": Object {
+                    "error": Object {
+                      "type": "string",
+                    },
+                    "validation": Object {
+                      "items": Object {
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": Array [
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The provided request data is invalid.",
+          },
+          "401": Object {
+            "description": "Authorization information is missing or invalid.",
+          },
+        },
+        "summary": "Register clients with Unleash.",
+        "tags": Array [
+          "Operational",
+          "Server-side client",
+        ],
+      },
+    },
+    "/frontend/health": Object {
+      "get": Object {
+        "description": "Returns a 200 OK if the proxy is ready to receive requests. Otherwise returns a 503 NOT READY.",
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "example": "ok",
+                  "type": "string",
+                },
+              },
+            },
+            "description": "The request was successful.",
+          },
+          "503": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "example": "The Unleash Proxy has not connected to the Unleash API and is not ready to accept requests yet.",
+                  "type": "string",
+                },
+              },
+            },
+            "description": "The proxy isn't ready to accept requests yet.",
+          },
+        },
+        "security": Array [],
+        "summary": "Check whether the proxy is ready to serve requests yet.",
+        "tags": Array [
+          "Operational",
+        ],
+      },
+    },
+    "/frontend/internal-backstage/prometheus": Object {
+      "get": Object {
+        "description": "Returns a 200 and valid Prometheus text syntax if the proxy is ready to receive requests. Otherwise returns a 503 NOT READY.",
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "example": "metric_name 1",
+                  "type": "string",
+                },
+              },
+            },
+            "description": "The request was successful. Response in plain text format conforming to Prometheus exposition format",
+          },
+          "503": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "example": "The Unleash Proxy has not connected to the Unleash API and is not ready to accept requests yet.",
+                  "type": "string",
+                },
+              },
+            },
+            "description": "The proxy isn't ready to accept requests yet.",
+          },
+        },
+        "security": Array [],
+        "summary": "Check whether the proxy is up and running",
+        "tags": Array [
+          "Operational",
+        ],
+      },
+    },
     "/proxy": Object {
       "get": Object {
         "description": "This endpoint returns the list of feature toggles that the proxy evaluates to enabled for the given context. Context values are provided as query parameters.",
@@ -830,7 +1529,7 @@ If you don't provide the \`toggles\` property, then this operation functions exa
     },
     "/proxy/all": Object {
       "get": Object {
-        "description": "This endpoint returns all feature toggles known to the proxy, along with whether they are enabled or disabled for the provided context. This endpoint always returns **all** feature toggles the proxy retrieves from Unleash, in contrast to the \`/proxy\` endpoints that only return enabled toggles.
+        "description": "This endpoint returns all feature toggles known to the proxy, along with whether they are enabled or disabled for the provided context. This endpoint always returns **all** feature toggles the proxy retrieves from Unleash, in contrast to the \`/frontend\` endpoints that only return enabled toggles.
 
 Useful if you are migrating to unleash and need to know if the feature flag exists on the Unleash server.
 

--- a/src/test/unleash-proxy.test.ts
+++ b/src/test/unleash-proxy.test.ts
@@ -58,6 +58,38 @@ test('Should return list of toggles', () => {
         });
 });
 
+test('Should treat /frontend as a valid alias of /proxy', () => {
+    const toggles = [
+        {
+            name: 'test',
+            enabled: true,
+            impressionData: true,
+        },
+        {
+            name: 'test2',
+            enabled: true,
+            impressionData: true,
+        },
+    ];
+    const client = new MockClient(toggles);
+
+    const proxySecrets = ['sdf'];
+    const app = createApp(
+        { proxySecrets, unleashUrl, unleashApiToken },
+        client,
+    );
+    client.emit('ready');
+
+    return request(app)
+        .get('/frontend')
+        .set('Authorization', 'sdf')
+        .expect(200)
+        .expect('Content-Type', /json/)
+        .then((response) => {
+            expect(response.body.toggles.length).toEqual(2);
+        });
+});
+
 test('Should handle POST with empty/nonsensical body', async () => {
     const toggles = [
         {

--- a/src/unleash-proxy.ts
+++ b/src/unleash-proxy.ts
@@ -132,7 +132,7 @@ export default class UnleashProxy {
                     ...standardResponses(401, 500, 501, 503),
                     200: featuresResponse,
                 },
-                description: `This endpoint returns all feature toggles known to the proxy, along with whether they are enabled or disabled for the provided context. This endpoint always returns **all** feature toggles the proxy retrieves from Unleash, in contrast to the \`/proxy\` endpoints that only return enabled toggles.
+                description: `This endpoint returns all feature toggles known to the proxy, along with whether they are enabled or disabled for the provided context. This endpoint always returns **all** feature toggles the proxy retrieves from Unleash, in contrast to the \`/frontend\` endpoints that only return enabled toggles.
 
 Useful if you are migrating to unleash and need to know if the feature flag exists on the Unleash server.
 
@@ -327,7 +327,7 @@ If you don't provide the \`toggles\` property, then this operation functions exa
     ): Promise<void> {
         if (!this.enableAllEndpoint) {
             res.status(501).send(
-                'The /proxy/all endpoint is disabled. Please check your server configuration. To enable it, set the `enableAllEndpoint` configuration option or `ENABLE_ALL_ENDPOINT` environment variable to `true`.',
+                'The /frontend/all endpoint is disabled. Please check your server configuration. To enable it, set the `enableAllEndpoint` configuration option or `ENABLE_ALL_ENDPOINT` environment variable to `true`.',
             );
             return;
         }
@@ -344,7 +344,7 @@ If you don't provide the \`toggles\` property, then this operation functions exa
     ): Promise<void> {
         if (!this.enableAllEndpoint) {
             res.status(501).send(
-                'The /proxy/all endpoint is disabled. Please check your server configuration. To enable it, set the `enableAllEndpoint` configuration option or `ENABLE_ALL_ENDPOINT` environment variable to `true`.',
+                'The /frontend/all endpoint is disabled. Please check your server configuration. To enable it, set the `enableAllEndpoint` configuration option or `ENABLE_ALL_ENDPOINT` environment variable to `true`.',
             );
             return;
         }


### PR DESCRIPTION
 - Adds a `/frontend` alias to `/proxy` to improve consistency with both the frontend API and Edge;
 - Adds a related test;
 - Adds a note to the README to consider using Unleash Edge instead;
 - Updates README and OpenAPI descriptions to match new endpoint;
 - Bumps version;