### PR TITLE
feat: proxy now respects incoming currentTime property

### DIFF
--- a/src/create-context.ts
+++ b/src/create-context.ts
@@ -1,6 +1,18 @@
 /* eslint-disable prefer-object-spread */
 import { Context } from 'unleash-client';
 
+function tryParseDate(dateString: string | undefined): Date | undefined {
+    if (!dateString) {
+        return undefined;
+    }
+    const parsedDate = new Date(dateString);
+    if (!isNaN(parsedDate.getTime())) {
+        return parsedDate;
+    } else {
+        return undefined;
+    }
+}
+
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function createContext(value: any): Context {
     const {
@@ -10,6 +22,7 @@ export function createContext(value: any): Context {
         sessionId,
         remoteAddress,
         properties,
+        currentTime,
         ...rest
     } = value;
 
@@ -20,6 +33,7 @@ export function createContext(value: any): Context {
         userId,
         sessionId,
         remoteAddress,
+        currentTime: tryParseDate(currentTime),
         properties: Object.assign({}, rest, properties),
     };
 

--- a/src/test/__snapshots__/openapi.test.ts.snap
+++ b/src/test/__snapshots__/openapi.test.ts.snap
@@ -645,6 +645,14 @@ Object {
             },
           },
           Object {
+            "description": "The current time in ISO 8601 format, representing the time at which the feature toggle is being resolved",
+            "in": "query",
+            "name": "currentTime",
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
             "description": "Additional (custom) context fields",
             "example": Object {
               "betaTester": "true",
@@ -864,6 +872,14 @@ However, using this endpoint will increase the payload size transmitted to your 
             "description": "Your application's IP address",
             "in": "query",
             "name": "remoteAddress",
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "description": "The current time in ISO 8601 format, representing the time at which the feature toggle is being resolved",
+            "in": "query",
+            "name": "currentTime",
             "schema": Object {
               "type": "string",
             },

--- a/src/test/create-context.test.ts
+++ b/src/test/create-context.test.ts
@@ -60,6 +60,31 @@ test('will not blow up if properties is an array', () => {
     expect(context).not.toHaveProperty('region');
 });
 
+test('accepts current time as a context value', () => {
+    const targetDate = new Date('2024-01-01T00:00:00.000Z');
+    const context = createContext({
+        currentTime: targetDate.toISOString(),
+    });
+
+    expect(context.currentTime).toStrictEqual(targetDate);
+});
+
+test('invalid time strings fall back to undefined currentTime', () => {
+    const context = createContext({
+        currentTime: 'its cute that you think this will parse',
+    });
+
+    expect(context).not.toHaveProperty('currentTime');
+});
+
+test('missing time current time falls back to undefined currentTime', () => {
+    const context = createContext({
+        userId: '123',
+    });
+
+    expect(context).not.toHaveProperty('currentTime');
+});
+
 test.skip('will not blow up if userId is an array', () => {
     const context = createContext({
         userId: ['123'],

--- a/src/unleash-proxy.ts
+++ b/src/unleash-proxy.ts
@@ -81,7 +81,8 @@ export default class UnleashProxy {
                         userId: "The current user's ID",
                         sessionId: "The current session's ID",
                         remoteAddress: "Your application's IP address",
-                        currentTime: "The current time in ISO 8601 format, representing the time at which the feature toggle is being resolved"
+                        currentTime:
+                            'The current time in ISO 8601 format, representing the time at which the feature toggle is being resolved',
                     }),
                     ...createDeepObjectRequestParameters({
                         properties: {
@@ -118,7 +119,8 @@ export default class UnleashProxy {
                         userId: "The current user's ID",
                         sessionId: "The current session's ID",
                         remoteAddress: "Your application's IP address",
-                        currentTime: "The current time in ISO 8601 format, representing the time at which the feature toggle is being resolved"
+                        currentTime:
+                            'The current time in ISO 8601 format, representing the time at which the feature toggle is being resolved',
                     }),
                     ...createDeepObjectRequestParameters({
                         properties: {

--- a/src/unleash-proxy.ts
+++ b/src/unleash-proxy.ts
@@ -81,6 +81,7 @@ export default class UnleashProxy {
                         userId: "The current user's ID",
                         sessionId: "The current session's ID",
                         remoteAddress: "Your application's IP address",
+                        currentTime: "The current time in ISO 8601 format, representing the time at which the feature toggle is being resolved"
                     }),
                     ...createDeepObjectRequestParameters({
                         properties: {
@@ -117,6 +118,7 @@ export default class UnleashProxy {
                         userId: "The current user's ID",
                         sessionId: "The current session's ID",
                         remoteAddress: "Your application's IP address",
+                        currentTime: "The current time in ISO 8601 format, representing the time at which the feature toggle is being resolved"
                     }),
                     ...createDeepObjectRequestParameters({
                         properties: {


### PR DESCRIPTION
This adds the current time property to the context enricher and uses that property during the calculation for feature toggles. 

Invalid and/or missing dates fallback to undefined to keep the logical flow consistent with SDKs