### PR TITLE
fix: allow clients to send metrics when using all path

### DIFF
--- a/src/test/__snapshots__/openapi.test.ts.snap
+++ b/src/test/__snapshots__/openapi.test.ts.snap
@@ -1093,6 +1093,79 @@ If you don't provide the \`toggles\` property, then this operation functions exa
         ],
       },
     },
+    "/proxy/all/client/metrics": Object {
+      "post": Object {
+        "description": "This endpoint lets you register usage metrics with Unleash. Accepts either one of the proxy's configured \`serverSideTokens\` or one of its \`clientKeys\` for authorization.",
+        "requestBody": Object {
+          "content": Object {
+            "application/json": Object {
+              "schema": Object {
+                "$ref": "#/components/schemas/registerMetricsSchema",
+              },
+            },
+          },
+        },
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "example": "ok",
+                  "type": "string",
+                },
+              },
+            },
+            "description": "The request was successful.",
+          },
+          "400": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "example": Object {
+                    "error": "Request validation failed",
+                    "validation": Array [
+                      Object {
+                        "dataPath": ".body",
+                        "keyword": "required",
+                        "message": "should have required property 'appName'",
+                        "params": Object {
+                          "missingProperty": "appName",
+                        },
+                        "schemaPath": "#/components/schemas/registerMetricsSchema/required",
+                      },
+                    ],
+                  },
+                  "properties": Object {
+                    "error": Object {
+                      "type": "string",
+                    },
+                    "validation": Object {
+                      "items": Object {
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": Array [
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The provided request data is invalid.",
+          },
+          "401": Object {
+            "description": "Authorization information is missing or invalid.",
+          },
+        },
+        "summary": "Send usage metrics to Unleash.",
+        "tags": Array [
+          "Operational",
+          "Server-side client",
+        ],
+      },
+    },
     "/proxy/client/features": Object {
       "get": Object {
         "description": "Returns the toggle configuration from the proxy's internal Unleash SDK. Use this to bootstrap other proxies and server-side SDKs. Requires you to provide one of the proxy's configured \`serverSideTokens\` for authorization.",

--- a/src/test/unleash-proxy.test.ts
+++ b/src/test/unleash-proxy.test.ts
@@ -390,6 +390,30 @@ test('Should register metrics', () => {
         .expect(200);
 });
 
+test('Should register metrics an /all path as well', () => {
+    const toggles = [
+        {
+            name: 'test',
+            enabled: true,
+            impressionData: true,
+        },
+    ];
+    const client = new MockClient(toggles);
+
+    const proxySecrets = ['sdf'];
+    const app = createApp(
+        { unleashUrl, unleashApiToken, proxySecrets },
+        client,
+    );
+    client.emit('ready');
+
+    return request(app)
+        .post('/proxy/all/client/metrics')
+        .send(metrics)
+        .set('Authorization', 'sdf')
+        .expect(200);
+});
+
 test('Should require metrics to have correct format', () => {
     const client = new MockClient();
 

--- a/src/unleash-proxy.ts
+++ b/src/unleash-proxy.ts
@@ -174,6 +174,19 @@ If you don't provide the \`toggles\` property, then this operation functions exa
         );
 
         router.post(
+            '/all/client/metrics',
+            openApiService.validPath({
+                requestBody: registerMetricsRequest,
+                responses: standardResponses(200, 400, 401),
+                description:
+                    "This endpoint lets you register usage metrics with Unleash. Accepts either one of the proxy's configured `serverSideTokens` or one of its `clientKeys` for authorization.",
+                summary: 'Send usage metrics to Unleash.',
+                tags: ['Operational', 'Server-side client'],
+            }),
+            this.registerMetrics.bind(this),
+        );
+
+        router.post(
             '',
             openApiService.validPath({
                 requestBody: lookupTogglesRequest,


### PR DESCRIPTION
fixes https://github.com/Unleash/unleash-android-proxy-sdk/issues/77