### PR TITLE
chore: v1.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unleash/proxy",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "The Unleash Proxy (Open-Source)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unleash/proxy",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "The Unleash Proxy (Open-Source)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Bumps version to v1.4.2. Tried:

```
npm version 1.4.1
git push --follow-tags
```

But I don't have access to push directly to main, so it failed to push the version bump. However this already released a 1.4.1 version since the tag was pushed. This time I'm opening this PR to bump the version and only then create a tag based on latest main, with the correct version.