### PR TITLE
chore: revert deprecate instanceid (#180), unleash client 6.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ You **must configure** these three variables for the proxy to start successfully
 | n/a | `PORT` or `PROXY_PORT` | 3000 | no | The port where the proxy should listen. |
 | proxyBasePath | `PROXY_BASE_PATH` | "" | no | The base path to run the proxy from. "/proxy" will be added at the end. For instance, if `proxyBasePath` is `"base/path"`, the proxy will run at `/base/path/proxy`. |
 | unleashAppName | `UNLEASH_APP_NAME` | "unleash-proxy" | no | App name to used when registering with Unleash |
-| unleashInstanceId | `UNLEASH_INSTANCE_ID` | `generated` | deprecated | Unleash instance id to used when registering with Unleash |
+| unleashInstanceId | `UNLEASH_INSTANCE_ID` | `generated` | no | Unleash instance id to used when registering with Unleash |
 | refreshInterval | `UNLEASH_FETCH_INTERVAL` | 5000 | no | How often the proxy should query Unleash for updates, defined in ms. |
 | metricsInterval | `UNLEASH_METRICS_INTERVAL` | 30000 | no | How often the proxy should send usage metrics back to Unleash, defined in ms. |
 | metricsJitter | `UNLEASH_METRICS_JITTER` | 0 | no | Adds jitter to the metrics interval to avoid multiple instances sending metrics at the same time, defined in ms. |

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "openapi-types": "^11.0.0",
     "qs": "^6.9.7",
     "type-is": "^1.6.18",
-    "unleash-client": "^6.0.0"
+    "unleash-client": "^5.6.1"
   },
   "devDependencies": {
     "@apidevtools/swagger-parser": "10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unleash/proxy",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "The Unleash Proxy (Open-Source)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -46,7 +46,7 @@
     "openapi-types": "^11.0.0",
     "qs": "^6.9.7",
     "type-is": "^1.6.18",
-    "unleash-client": "^5.6.1"
+    "unleash-client": "^6.1.0"
   },
   "devDependencies": {
     "@apidevtools/swagger-parser": "10.1.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,10 +49,6 @@ export interface IProxyConfig {
     unleashUrl: string;
     unleashApiToken: string;
     unleashAppName: string;
-    /**
-     * @deprecated This property is deprecated and will be removed in a future version.
-     * Note: This property is currently a no-op (no operation) and does not affect the automatically generated instanceId.
-     */
     unleashInstanceId: string;
     customStrategies?: Strategy[];
     clientKeys: string[];

--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -12,6 +12,7 @@ export const createSingletonClient = (config: IProxyConfig): Client => {
     const unleash = initialize({
         url: config.unleashUrl,
         appName: config.unleashAppName,
+        instanceId: config.unleashInstanceId,
         environment: config.environment,
         refreshInterval: config.refreshInterval,
         projectName: config.projectName,
@@ -48,6 +49,7 @@ export const createNewClient = (config: IProxyConfig): Client => {
     const unleash = new Unleash({
         url: config.unleashUrl,
         appName: config.unleashAppName,
+        instanceId: config.unleashInstanceId,
         environment: config.environment,
         refreshInterval: config.refreshInterval,
         projectName: config.projectName,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4962,10 +4962,10 @@ unique-slug@^4.0.0:
   dependencies:
     imurmurhash "^0.1.4"
 
-unleash-client@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/unleash-client/-/unleash-client-6.0.0.tgz#03af4bd3177647e356b6c7a572d94ec611c2da4f"
-  integrity sha512-qvnFtlV5zCGhXC/4Soqe1FCRjes61HuJYXysHwnUplNd5qItX51S9f+oRu2WzIdBp+kiYU5SwT2sSWEJK+OTaQ==
+unleash-client@^5.6.1:
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/unleash-client/-/unleash-client-5.6.1.tgz#a730da7cced1fa2ccdf3d41d0d8f93f8bb0e8976"
+  integrity sha512-ZmFDhnq0c3Y4CEp+S3ureS9jZFMG/mtyafv4zxW4pmG0vc7xgxE9zBX296lrrrINsc2G0/2uJeoO+9b0bks+mg==
   dependencies:
     http-proxy-agent "^7.0.2"
     https-proxy-agent "^7.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4962,10 +4962,10 @@ unique-slug@^4.0.0:
   dependencies:
     imurmurhash "^0.1.4"
 
-unleash-client@^5.6.1:
-  version "5.6.1"
-  resolved "https://registry.yarnpkg.com/unleash-client/-/unleash-client-5.6.1.tgz#a730da7cced1fa2ccdf3d41d0d8f93f8bb0e8976"
-  integrity sha512-ZmFDhnq0c3Y4CEp+S3ureS9jZFMG/mtyafv4zxW4pmG0vc7xgxE9zBX296lrrrINsc2G0/2uJeoO+9b0bks+mg==
+unleash-client@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/unleash-client/-/unleash-client-6.1.0.tgz#b8863bb049b61d702b7c45328d6225a0c9f9b67a"
+  integrity sha512-dXTnWorA5NfddqZfMPcTe6xl+uu9CxkpR5wLuKKLLpvHuNzMrTlwDOfaQqFHlfPx+8xudQQ0fZx4raNxL3GLOg==
   dependencies:
     http-proxy-agent "^7.0.2"
     https-proxy-agent "^7.0.5"


### PR DESCRIPTION
https://linear.app/unleash/issue/2-2431/revert-autogenned-instance-id-proxy

Reverts: https://github.com/Unleash/unleash-proxy/pull/180 and bumps `unleash-client` to `v6.1.0`.

Also bumps the proxy version to `1.4.3` so we can make a new release from main after merging and avoid a PR like https://github.com/Unleash/unleash-proxy/pull/183