### PR TITLE
chore: bump unleash-client to v6.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unleash/proxy",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "The Unleash Proxy (Open-Source)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -46,7 +46,7 @@
     "openapi-types": "^11.0.0",
     "qs": "^6.9.7",
     "type-is": "^1.6.18",
-    "unleash-client": "^6.1.0"
+    "unleash-client": "^6.1.1"
   },
   "devDependencies": {
     "@apidevtools/swagger-parser": "10.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4962,10 +4962,10 @@ unique-slug@^4.0.0:
   dependencies:
     imurmurhash "^0.1.4"
 
-unleash-client@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/unleash-client/-/unleash-client-6.1.0.tgz#b8863bb049b61d702b7c45328d6225a0c9f9b67a"
-  integrity sha512-dXTnWorA5NfddqZfMPcTe6xl+uu9CxkpR5wLuKKLLpvHuNzMrTlwDOfaQqFHlfPx+8xudQQ0fZx4raNxL3GLOg==
+unleash-client@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/unleash-client/-/unleash-client-6.1.1.tgz#0a53f2646f100c098708b860aa0b7991f0986e39"
+  integrity sha512-nAQw4SDjPd1J7JN6KD9o+5R1zhGOVhdbAWbpwXwhCi25ofpQVLpsVMpJvaztog1EZUrRd7oZcS21zvrrqZpP9A==
   dependencies:
     http-proxy-agent "^7.0.2"
     https-proxy-agent "^7.0.5"


### PR DESCRIPTION
https://linear.app/unleash/issue/2-2468/fix-trim-is-not-a-function-edge-case-on-context-value

Bumps `unleash-client` to `v6.1.1` and prepares for a `v1.4.4` Unleash Proxy release.

Related issue: https://github.com/Unleash/unleash-proxy/issues/185