### PR TITLE
chore: bump to upstream version of openapi

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/Unleash/unleash-proxy#readme",
   "dependencies": {
-    "@unleash/express-openapi": "^0.3.0",
+    "@wesleytodd/openapi": "^1.1.0",
     "compression": "^1.7.4",
     "cors": "^2.8.5",
     "express": "^4.21.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-import { createApp } from "./app";
-import Client from "./client";
-import { createProxyConfig } from "./config";
-import { start } from "./server";
+import { createApp } from './app';
+import Client from './client';
+import { createProxyConfig } from './config';
+import { start } from './server';
 
 export { createApp, start, Client, createProxyConfig };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,6 @@
-/// <reference path="./types/openapi.d.ts" />
-
-import { createApp } from './app';
-import Client from './client';
-import { createProxyConfig } from './config';
-import { start } from './server';
+import { createApp } from "./app";
+import Client from "./client";
+import { createProxyConfig } from "./config";
+import { start } from "./server";
 
 export { createApp, start, Client, createProxyConfig };

--- a/src/openapi/openapi-service.ts
+++ b/src/openapi/openapi-service.ts
@@ -1,59 +1,62 @@
-import openapi, { type IExpressOpenApi } from "@wesleytodd/openapi";
-import type { Application, RequestHandler } from "express";
-import type { OpenAPIV3 } from "openapi-types";
-import { createOpenApiSchema } from ".";
-import type { IProxyConfig } from "../config";
-import { format500ErrorMessage } from "./common-responses";
+import openapi, { type IExpressOpenApi } from '@wesleytodd/openapi';
+import type { Application, RequestHandler } from 'express';
+import type { OpenAPIV3 } from 'openapi-types';
+import { createOpenApiSchema } from '.';
+import type { IProxyConfig } from '../config';
+import { format500ErrorMessage } from './common-responses';
 
 export class OpenApiService {
-  private readonly config: IProxyConfig;
+    private readonly config: IProxyConfig;
 
-  private readonly api: IExpressOpenApi;
+    private readonly api: IExpressOpenApi;
 
-  constructor(config: IProxyConfig) {
-    this.config = config;
-    this.api = openapi(
-      this.docsPath(),
-      createOpenApiSchema(config.proxyBasePath, config.clientKeysHeaderName),
-      { coerce: true },
-    );
-  }
+    constructor(config: IProxyConfig) {
+        this.config = config;
+        this.api = openapi(
+            this.docsPath(),
+            createOpenApiSchema(
+                config.proxyBasePath,
+                config.clientKeysHeaderName,
+            ),
+            { coerce: true },
+        );
+    }
 
-  docsPath(): string {
-    return `${this.config.proxyBasePath}/docs/openapi`;
-  }
+    docsPath(): string {
+        return `${this.config.proxyBasePath}/docs/openapi`;
+    }
 
-  // Serve the OpenAPI JSON at `${this.docsPath()}.json`,
-  // and the OpenAPI SwaggerUI at `${this.docsPathPath}`.
-  useDocs(app: Application): void {
-    app.use(this.api);
-    app.use(this.docsPath(), this.api.swaggerui());
-  }
+    // Serve the OpenAPI JSON at `${this.docsPath()}.json`,
+    // and the OpenAPI SwaggerUI at `${this.docsPathPath}`.
+    useDocs(app: Application): void {
+        app.use(this.api);
+        app.use(this.docsPath(), this.api.swaggerui());
+    }
 
-  // Create request validation middleware
-  validPath(op: OpenAPIV3.OperationObject): RequestHandler {
-    return this.api.validPath(op);
-  }
+    // Create request validation middleware
+    validPath(op: OpenAPIV3.OperationObject): RequestHandler {
+        return this.api.validPath(op);
+    }
 
-  // Catch and format Open API validation errors.
-  useErrorHandler(app: Application): void {
-    app.use((err: any, _: any, res: any, next: any) => {
-      if (err?.status && err.validationErrors) {
-        res.status(err.statusCode).json({
-          error: err.message,
-          validation: err.validationErrors,
+    // Catch and format Open API validation errors.
+    useErrorHandler(app: Application): void {
+        app.use((err: any, _: any, res: any, next: any) => {
+            if (err?.status && err.validationErrors) {
+                res.status(err.statusCode).json({
+                    error: err.message,
+                    validation: err.validationErrors,
+                });
+            } else if (err instanceof SyntaxError) {
+                res.status(400).json({
+                    error: `We were unable to parse the data you provided. Please check it for syntax errors. The message we got was: "${err.message}"`,
+                });
+            } else if (err) {
+                res.status(500).json({
+                    error: format500ErrorMessage(err.message),
+                });
+            } else {
+                next();
+            }
         });
-      } else if (err instanceof SyntaxError) {
-        res.status(400).json({
-          error: `We were unable to parse the data you provided. Please check it for syntax errors. The message we got was: "${err.message}"`,
-        });
-      } else if (err) {
-        res.status(500).json({
-          error: format500ErrorMessage(err.message),
-        });
-      } else {
-        next();
-      }
-    });
-  }
+    }
 }

--- a/src/openapi/openapi-service.ts
+++ b/src/openapi/openapi-service.ts
@@ -1,62 +1,59 @@
-import openapi, { type IExpressOpenApi } from '@unleash/express-openapi';
-import type { Application, RequestHandler } from 'express';
-import type { OpenAPIV3 } from 'openapi-types';
-import { createOpenApiSchema } from '.';
-import type { IProxyConfig } from '../config';
-import { format500ErrorMessage } from './common-responses';
+import openapi, { type IExpressOpenApi } from "@wesleytodd/openapi";
+import type { Application, RequestHandler } from "express";
+import type { OpenAPIV3 } from "openapi-types";
+import { createOpenApiSchema } from ".";
+import type { IProxyConfig } from "../config";
+import { format500ErrorMessage } from "./common-responses";
 
 export class OpenApiService {
-    private readonly config: IProxyConfig;
+  private readonly config: IProxyConfig;
 
-    private readonly api: IExpressOpenApi;
+  private readonly api: IExpressOpenApi;
 
-    constructor(config: IProxyConfig) {
-        this.config = config;
-        this.api = openapi(
-            this.docsPath(),
-            createOpenApiSchema(
-                config.proxyBasePath,
-                config.clientKeysHeaderName,
-            ),
-            { coerce: true },
-        );
-    }
+  constructor(config: IProxyConfig) {
+    this.config = config;
+    this.api = openapi(
+      this.docsPath(),
+      createOpenApiSchema(config.proxyBasePath, config.clientKeysHeaderName),
+      { coerce: true },
+    );
+  }
 
-    docsPath(): string {
-        return `${this.config.proxyBasePath}/docs/openapi`;
-    }
+  docsPath(): string {
+    return `${this.config.proxyBasePath}/docs/openapi`;
+  }
 
-    // Serve the OpenAPI JSON at `${this.docsPath()}.json`,
-    // and the OpenAPI SwaggerUI at `${this.docsPathPath}`.
-    useDocs(app: Application): void {
-        app.use(this.api);
-        app.use(this.docsPath(), this.api.swaggerui);
-    }
+  // Serve the OpenAPI JSON at `${this.docsPath()}.json`,
+  // and the OpenAPI SwaggerUI at `${this.docsPathPath}`.
+  useDocs(app: Application): void {
+    app.use(this.api);
+    app.use(this.docsPath(), this.api.swaggerui());
+  }
 
-    // Create request validation middleware
-    validPath(op: OpenAPIV3.OperationObject): RequestHandler {
-        return this.api.validPath(op);
-    }
+  // Create request validation middleware
+  validPath(op: OpenAPIV3.OperationObject): RequestHandler {
+    return this.api.validPath(op);
+  }
 
-    // Catch and format Open API validation errors.
-    useErrorHandler(app: Application): void {
-        app.use((err: any, _: any, res: any, next: any) => {
-            if (err?.status && err.validationErrors) {
-                res.status(err.statusCode).json({
-                    error: err.message,
-                    validation: err.validationErrors,
-                });
-            } else if (err instanceof SyntaxError) {
-                res.status(400).json({
-                    error: `We were unable to parse the data you provided. Please check it for syntax errors. The message we got was: "${err.message}"`,
-                });
-            } else if (err) {
-                res.status(500).json({
-                    error: format500ErrorMessage(err.message),
-                });
-            } else {
-                next();
-            }
+  // Catch and format Open API validation errors.
+  useErrorHandler(app: Application): void {
+    app.use((err: any, _: any, res: any, next: any) => {
+      if (err?.status && err.validationErrors) {
+        res.status(err.statusCode).json({
+          error: err.message,
+          validation: err.validationErrors,
         });
-    }
+      } else if (err instanceof SyntaxError) {
+        res.status(400).json({
+          error: `We were unable to parse the data you provided. Please check it for syntax errors. The message we got was: "${err.message}"`,
+        });
+      } else if (err) {
+        res.status(500).json({
+          error: format500ErrorMessage(err.message),
+        });
+      } else {
+        next();
+      }
+    });
+  }
 }

--- a/src/types/openapi.d.ts
+++ b/src/types/openapi.d.ts
@@ -1,16 +1,16 @@
 // Partial types for "@unleash/express-openapi".
-declare module '@unleash/express-openapi' {
-    import type { RequestHandler } from 'express';
+declare module "@wesleytodd/openapi" {
+  import type { RequestHandler } from "express";
 
-    export interface IExpressOpenApi extends RequestHandler {
-        validPath: (operation: OpenAPIV3.OperationObject) => RequestHandler;
-        schema: (name: string, schema: OpenAPIV3.SchemaObject) => void;
-        swaggerui: RequestHandler;
-    }
+  export interface IExpressOpenApi extends RequestHandler {
+    validPath: (operation: OpenAPIV3.OperationObject) => RequestHandler;
+    schema: (name: string, schema: OpenAPIV3.SchemaObject) => void;
+    swaggerui: () => RequestHandler;
+  }
 
-    export default function openapi(
-        docsPath: string,
-        document: Omit<OpenAPIV3.Document, 'paths'>,
-        options?: { coerce: boolean },
-    ): IExpressOpenApi;
+  export default function openapi(
+    docsPath: string,
+    document: Omit<OpenAPIV3.Document, "paths">,
+    options?: { coerce: boolean },
+  ): IExpressOpenApi;
 }

--- a/src/types/openapi.d.ts
+++ b/src/types/openapi.d.ts
@@ -1,16 +1,16 @@
 // Partial types for "@unleash/express-openapi".
-declare module "@wesleytodd/openapi" {
-  import type { RequestHandler } from "express";
+declare module '@wesleytodd/openapi' {
+    import type { RequestHandler } from 'express';
 
-  export interface IExpressOpenApi extends RequestHandler {
-    validPath: (operation: OpenAPIV3.OperationObject) => RequestHandler;
-    schema: (name: string, schema: OpenAPIV3.SchemaObject) => void;
-    swaggerui: () => RequestHandler;
-  }
+    export interface IExpressOpenApi extends RequestHandler {
+        validPath: (operation: OpenAPIV3.OperationObject) => RequestHandler;
+        schema: (name: string, schema: OpenAPIV3.SchemaObject) => void;
+        swaggerui: () => RequestHandler;
+    }
 
-  export default function openapi(
-    docsPath: string,
-    document: Omit<OpenAPIV3.Document, "paths">,
-    options?: { coerce: boolean },
-  ): IExpressOpenApi;
+    export default function openapi(
+        docsPath: string,
+        document: Omit<OpenAPIV3.Document, 'paths'>,
+        options?: { coerce: boolean },
+    ): IExpressOpenApi;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,14 +36,14 @@ __metadata:
   linkType: hard
 
 "@apidevtools/json-schema-ref-parser@npm:^9.0.6":
-  version: 9.0.9
-  resolution: "@apidevtools/json-schema-ref-parser@npm:9.0.9"
+  version: 9.1.2
+  resolution: "@apidevtools/json-schema-ref-parser@npm:9.1.2"
   dependencies:
     "@jsdevtools/ono": "npm:^7.1.3"
     "@types/json-schema": "npm:^7.0.6"
     call-me-maybe: "npm:^1.0.1"
     js-yaml: "npm:^4.1.0"
-  checksum: 10c0/d1457e57ca12abcd3da25b9a2cb2982267102c65aefeaf284a3321b818090b9032d6b7a3ad9625abc00d07f5b1432d643f79aa6f515c1a787523d40563ef85e4
+  checksum: 10c0/ebf952eb2e00bf0919f024e72897e047fd5012f0a9e47ac361873f6de0a733b9334513cdbc73205a6b43ac4a652b8c87f55e489c39b2d60bd0bc1cb2b411e218
   languageName: node
   linkType: hard
 
@@ -1613,9 +1613,9 @@ __metadata:
   linkType: hard
 
 "@types/json-schema@npm:^7.0.6":
-  version: 7.0.11
-  resolution: "@types/json-schema@npm:7.0.11"
-  checksum: 10c0/bd1f9a7b898ff15c4bb494eb19124f2d688b804c39f07cbf135ac73f35324970e9e8329b72aae1fb543d925ea295a1568b23056c26658cecec4741fa28c3b81a
+  version: 7.0.15
+  resolution: "@types/json-schema@npm:7.0.15"
+  checksum: 10c0/a996a745e6c5d60292f36731dd41341339d4eeed8180bb09226e5c8d23759067692b1d88e5d91d72ee83dfc00d3aca8e7bd43ea120516c17922cbcb7c3e252db
   languageName: node
   linkType: hard
 
@@ -1751,22 +1751,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@unleash/express-openapi@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "@unleash/express-openapi@npm:0.3.0"
-  dependencies:
-    ajv: "npm:^6.10.2"
-    http-errors: "npm:^1.7.3"
-    merge-deep: "npm:^3.0.2"
-    path-to-regexp: "npm:^2.4.0"
-    router: "npm:^1.3.3"
-    serve-static: "npm:^1.13.2"
-    swagger-parser: "npm:^10.0.3"
-    swagger-ui-dist: "npm:^4.10.3"
-  checksum: 10c0/54000d35bab88fda64f06abce96b7da4f836706295d8c56289da1c30ff5dc8f288b58f2e7f88ce4004344119829763e2766ea249099ec2b95a30c4481ee45783
-  languageName: node
-  linkType: hard
-
 "@unleash/proxy@workspace:.":
   version: 0.0.0-use.local
   resolution: "@unleash/proxy@workspace:."
@@ -1781,7 +1765,7 @@ __metadata:
     "@types/node": "npm:20.14.8"
     "@types/supertest": "npm:^6.0.2"
     "@types/type-is": "npm:^1.6.6"
-    "@unleash/express-openapi": "npm:^0.3.0"
+    "@wesleytodd/openapi": "npm:^1.1.0"
     babel-jest: "npm:^29.7.0"
     compression: "npm:^1.7.4"
     cors: "npm:^2.8.5"
@@ -1800,6 +1784,25 @@ __metadata:
     unleash-client: "npm:^6.1.1"
   languageName: unknown
   linkType: soft
+
+"@wesleytodd/openapi@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@wesleytodd/openapi@npm:1.1.0"
+  dependencies:
+    ajv: "npm:^8.12.0"
+    ajv-formats: "npm:^2.1.1"
+    ajv-keywords: "npm:^5.1.0"
+    http-errors: "npm:^2.0.0"
+    merge-deep: "npm:^3.0.3"
+    path-to-regexp: "npm:^6.2.1"
+    router: "npm:^1.3.8"
+    serve-static: "npm:^1.15.0"
+    swagger-parser: "npm:^10.0.3"
+    swagger-ui-dist: "npm:^5.11.8"
+    yaml: "npm:^2.4.0"
+  checksum: 10c0/3fd07e02c6ef98c9029e8ac8cf6e602eab1a162c9bccd4af6ca2858b26ae0c9eba5bf37b1c88912c831fdbbf38674cfeff59765db6b0c050411eea5efac7a574
+  languageName: node
+  linkType: hard
 
 "abbrev@npm:^2.0.0":
   version: 2.0.0
@@ -1867,15 +1870,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^6.10.2":
-  version: 6.12.6
-  resolution: "ajv@npm:6.12.6"
+"ajv-formats@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "ajv-formats@npm:2.1.1"
   dependencies:
-    fast-deep-equal: "npm:^3.1.1"
-    fast-json-stable-stringify: "npm:^2.0.0"
-    json-schema-traverse: "npm:^0.4.1"
-    uri-js: "npm:^4.2.2"
-  checksum: 10c0/41e23642cbe545889245b9d2a45854ebba51cda6c778ebced9649420d9205f2efb39cb43dbc41e358409223b1ea43303ae4839db682c848b891e4811da1a5a71
+    ajv: "npm:^8.0.0"
+  peerDependencies:
+    ajv: ^8.0.0
+  peerDependenciesMeta:
+    ajv:
+      optional: true
+  checksum: 10c0/e43ba22e91b6a48d96224b83d260d3a3a561b42d391f8d3c6d2c1559f9aa5b253bfb306bc94bbeca1d967c014e15a6efe9a207309e95b3eaae07fcbcdc2af662
+  languageName: node
+  linkType: hard
+
+"ajv-keywords@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "ajv-keywords@npm:5.1.0"
+  dependencies:
+    fast-deep-equal: "npm:^3.1.3"
+  peerDependencies:
+    ajv: ^8.8.2
+  checksum: 10c0/18bec51f0171b83123ba1d8883c126e60c6f420cef885250898bf77a8d3e65e3bfb9e8564f497e30bdbe762a83e0d144a36931328616a973ee669dc74d4a9590
+  languageName: node
+  linkType: hard
+
+"ajv@npm:^8.0.0, ajv@npm:^8.12.0":
+  version: 8.17.1
+  resolution: "ajv@npm:8.17.1"
+  dependencies:
+    fast-deep-equal: "npm:^3.1.3"
+    fast-uri: "npm:^3.0.1"
+    json-schema-traverse: "npm:^1.0.0"
+    require-from-string: "npm:^2.0.2"
+  checksum: 10c0/ec3ba10a573c6b60f94639ffc53526275917a2df6810e4ab5a6b959d87459f9ef3f00d5e7865b82677cb7d21590355b34da14d1d0b9c32d75f95a187e76fff35
   languageName: node
   linkType: hard
 
@@ -2482,10 +2510,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^2.20.3":
-  version: 2.20.3
-  resolution: "commander@npm:2.20.3"
-  checksum: 10c0/74c781a5248c2402a0a3e966a0a2bba3c054aad144f5c023364be83265e796b20565aa9feff624132ff629aa64e16999fa40a743c10c12f7c61e96a794b99288
+"commander@npm:^9.4.1":
+  version: 9.5.0
+  resolution: "commander@npm:9.5.0"
+  checksum: 10c0/5f7784fbda2aaec39e89eb46f06a999e00224b3763dc65976e05929ec486e174fe9aac2655f03ba6a5e83875bd173be5283dc19309b7c65954701c02025b3c1d
   languageName: node
   linkType: hard
 
@@ -2688,13 +2716,6 @@ __metadata:
   version: 2.0.0
   resolution: "depd@npm:2.0.0"
   checksum: 10c0/58bd06ec20e19529b06f7ad07ddab60e504d9e0faca4bd23079fac2d279c3594334d736508dc350e06e510aba5e22e4594483b3a6562ce7c17dd797f4cc4ad2c
-  languageName: node
-  linkType: hard
-
-"depd@npm:~1.1.2":
-  version: 1.1.2
-  resolution: "depd@npm:1.1.2"
-  checksum: 10c0/acb24aaf936ef9a227b6be6d495f0d2eb20108a9a6ad40585c5bda1a897031512fef6484e4fdbb80bd249fdaa82841fa1039f416ece03188e677ba11bcfda249
   languageName: node
   linkType: hard
 
@@ -2979,14 +3000,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-deep-equal@npm:^3.1.1":
+"fast-deep-equal@npm:^3.1.1, fast-deep-equal@npm:^3.1.3":
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
   checksum: 10c0/40dedc862eb8992c54579c66d914635afbec43350afbbe991235fdcb4e3a8d5af1b23ae7e79bef7d4882d0ecee06c3197488026998fb19f72dc95acff1d1b1d0
   languageName: node
   linkType: hard
 
-"fast-json-stable-stringify@npm:2.x, fast-json-stable-stringify@npm:^2.0.0, fast-json-stable-stringify@npm:^2.1.0":
+"fast-json-stable-stringify@npm:2.x, fast-json-stable-stringify@npm:^2.1.0":
   version: 2.1.0
   resolution: "fast-json-stable-stringify@npm:2.1.0"
   checksum: 10c0/7f081eb0b8a64e0057b3bb03f974b3ef00135fbf36c1c710895cd9300f13c94ba809bb3a81cf4e1b03f6e5285610a61abbd7602d0652de423144dfee5a389c9b
@@ -2997,6 +3018,13 @@ __metadata:
   version: 2.1.1
   resolution: "fast-safe-stringify@npm:2.1.1"
   checksum: 10c0/d90ec1c963394919828872f21edaa3ad6f1dddd288d2bd4e977027afff09f5db40f94e39536d4646f7e01761d704d72d51dce5af1b93717f3489ef808f5f4e4d
+  languageName: node
+  linkType: hard
+
+"fast-uri@npm:^3.0.1":
+  version: 3.0.2
+  resolution: "fast-uri@npm:3.0.2"
+  checksum: 10c0/8cdd3da7b4022a037d348d587d55caff74b7e4f862bbdd2cc35c1e6e3f97d0aedb567894d44c57ee8798d3192cceb97dcf41dbdabfa07dd2842a0474a6c6eeef
   languageName: node
   linkType: hard
 
@@ -3337,7 +3365,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-errors@npm:2.0.0":
+"http-errors@npm:2.0.0, http-errors@npm:^2.0.0":
   version: 2.0.0
   resolution: "http-errors@npm:2.0.0"
   dependencies:
@@ -3347,19 +3375,6 @@ __metadata:
     statuses: "npm:2.0.1"
     toidentifier: "npm:1.0.1"
   checksum: 10c0/fc6f2715fe188d091274b5ffc8b3657bd85c63e969daa68ccb77afb05b071a4b62841acb7a21e417b5539014dff2ebf9550f0b14a9ff126f2734a7c1387f8e19
-  languageName: node
-  linkType: hard
-
-"http-errors@npm:^1.7.3":
-  version: 1.8.1
-  resolution: "http-errors@npm:1.8.1"
-  dependencies:
-    depd: "npm:~1.1.2"
-    inherits: "npm:2.0.4"
-    setprototypeof: "npm:1.2.0"
-    statuses: "npm:>= 1.5.0 < 2"
-    toidentifier: "npm:1.0.1"
-  checksum: 10c0/f01aeecd76260a6fe7f08e192fcbe9b2f39ed20fc717b852669a69930167053b01790998275c6297d44f435cf0e30edd50c05223d1bec9bc484e6cf35b2d6f43
   languageName: node
   linkType: hard
 
@@ -4195,13 +4210,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-schema-traverse@npm:^0.4.1":
-  version: 0.4.1
-  resolution: "json-schema-traverse@npm:0.4.1"
-  checksum: 10c0/108fa90d4cc6f08243aedc6da16c408daf81793bf903e9fd5ab21983cda433d5d2da49e40711da016289465ec2e62e0324dcdfbc06275a607fe3233fde4942ce
-  languageName: node
-  linkType: hard
-
 "json-schema-traverse@npm:^1.0.0":
   version: 1.0.0
   resolution: "json-schema-traverse@npm:1.0.0"
@@ -4385,7 +4393,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"merge-deep@npm:^3.0.2":
+"merge-deep@npm:^3.0.3":
   version: 3.0.3
   resolution: "merge-deep@npm:3.0.3"
   dependencies:
@@ -4924,10 +4932,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:^2.4.0":
-  version: 2.4.0
-  resolution: "path-to-regexp@npm:2.4.0"
-  checksum: 10c0/286e3f2ea633ae9447d9c6beb2974db67801ffd64927e70129604e1fb987d94c9b38fa70cc494cd088c78d521914edec87de7f11928848c9ac265632c8644fc8
+"path-to-regexp@npm:^6.2.1":
+  version: 6.3.0
+  resolution: "path-to-regexp@npm:6.3.0"
+  checksum: 10c0/73b67f4638b41cde56254e6354e46ae3a2ebc08279583f6af3d96fe4664fc75788f74ed0d18ca44fa4a98491b69434f9eee73b97bb5314bd1b5adb700f5c18d6
   languageName: node
   linkType: hard
 
@@ -5172,9 +5180,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"router@npm:^1.3.3":
-  version: 1.3.7
-  resolution: "router@npm:1.3.7"
+"router@npm:^1.3.8":
+  version: 1.3.8
+  resolution: "router@npm:1.3.8"
   dependencies:
     array-flatten: "npm:3.0.0"
     debug: "npm:2.6.9"
@@ -5183,7 +5191,7 @@ __metadata:
     path-to-regexp: "npm:0.1.7"
     setprototypeof: "npm:1.2.0"
     utils-merge: "npm:1.0.1"
-  checksum: 10c0/3187cf54e1e476c009a86504812066ce59e977605f4fd5f9ffbf5cf5062e9b6360e512d277fb09264f9567c547934ec28a2863656be0352a80a547b3a4155de5
+  checksum: 10c0/328adcea82ac4dc120aa84e29904003dd55bfd79bb444813a07ab7c08cf19f16ab5bfaecb88ff34f9e086b15a43ffa879ae95271693e689364fdaae9c5e4e304
   languageName: node
   linkType: hard
 
@@ -5267,7 +5275,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serve-static@npm:1.16.2, serve-static@npm:^1.13.2":
+"serve-static@npm:1.16.2, serve-static@npm:^1.15.0":
   version: 1.16.2
   resolution: "serve-static@npm:1.16.2"
   dependencies:
@@ -5454,13 +5462,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"statuses@npm:>= 1.5.0 < 2":
-  version: 1.5.0
-  resolution: "statuses@npm:1.5.0"
-  checksum: 10c0/e433900956357b3efd79b1c547da4d291799ac836960c016d10a98f6a810b1b5c0dcc13b5a7aa609a58239b5190e1ea176ad9221c2157d2fd1c747393e6b2940
-  languageName: node
-  linkType: hard
-
 "string-length@npm:^4.0.1":
   version: 4.0.2
   resolution: "string-length@npm:4.0.2"
@@ -5625,10 +5626,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"swagger-ui-dist@npm:^4.10.3":
-  version: 4.11.0
-  resolution: "swagger-ui-dist@npm:4.11.0"
-  checksum: 10c0/2f2944fb2eb34ee03b5fa255be6addde076656c441d733ec55232a65e3d64026d9c2832ec9b330ddd1da92c70504b852b1fce903266448bcd2f4124b677269ce
+"swagger-ui-dist@npm:^5.11.8":
+  version: 5.17.14
+  resolution: "swagger-ui-dist@npm:5.17.14"
+  checksum: 10c0/cb61bba39e76d7d0d83da605a55e9504c1a5b421f9f13cced06d3e222f0a291594d417ec57b30a38aabe30d8a7e257c4977b8f0bba0e865d60f92b0a8ef4dfc1
   languageName: node
   linkType: hard
 
@@ -5965,9 +5966,9 @@ __metadata:
   linkType: hard
 
 "validator@npm:^13.7.0":
-  version: 13.7.0
-  resolution: "validator@npm:13.7.0"
-  checksum: 10c0/234c9db98001d6f75c04174dd7f67a297728c8cb369db99f21c41ba4a254558bf91427ecdcc9017ddcd44271c9db38e96079cf432a41c92f13d96d6ca0d5c28d
+  version: 13.12.0
+  resolution: "validator@npm:13.12.0"
+  checksum: 10c0/21d48a7947c9e8498790550f56cd7971e0e3d724c73388226b109c1bac2728f4f88caddfc2f7ed4b076f9b0d004316263ac786a17e9c4edf075741200718cd32
   languageName: node
   linkType: hard
 
@@ -6065,6 +6066,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yaml@npm:^2.4.0":
+  version: 2.5.1
+  resolution: "yaml@npm:2.5.1"
+  bin:
+    yaml: bin.mjs
+  checksum: 10c0/40fba5682898dbeeb3319e358a968fe886509fab6f58725732a15f8dda3abac509f91e76817c708c9959a15f786f38ff863c1b88062d7c1162c5334a7d09cb4a
+  languageName: node
+  linkType: hard
+
 "yargs-parser@npm:^21.0.0":
   version: 21.0.1
   resolution: "yargs-parser@npm:21.0.1"
@@ -6109,10 +6119,10 @@ __metadata:
   linkType: hard
 
 "z-schema@npm:^5.0.1":
-  version: 5.0.3
-  resolution: "z-schema@npm:5.0.3"
+  version: 5.0.5
+  resolution: "z-schema@npm:5.0.5"
   dependencies:
-    commander: "npm:^2.20.3"
+    commander: "npm:^9.4.1"
     lodash.get: "npm:^4.4.2"
     lodash.isequal: "npm:^4.5.0"
     validator: "npm:^13.7.0"
@@ -6121,6 +6131,6 @@ __metadata:
       optional: true
   bin:
     z-schema: bin/z-schema
-  checksum: 10c0/bc61def40d7fbed793c7ed9b2d1e01f2f9641a90be5027da66b6f9489a668149f1920e3d60ab4f72d155435c750a154dc75b24c761fff9df3a03bb5b97c7b946
+  checksum: 10c0/e4c812cfe6468c19b2a21d07d4ff8fb70359062d33400b45f89017eaa3efe9d51e85963f2b115eaaa99a16b451782249bf9b1fa8b31d35cc473e7becb3e44264
   languageName: node
   linkType: hard


### PR DESCRIPTION
This is the work done in #195, just keeping strict: true, and updating our type definitions to reflect upstream openapi

Co-Authored-By: skyd0me