### PR TITLE
chore: use trusted publishers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build:
 
@@ -30,9 +34,7 @@ jobs:
     - run: |
         LATEST=$(npm show @unleash/proxy version)
         TAG=$(node scripts/npm-tag.js $LATEST)
-        npm publish --tag ${TAG:-latest}
-      env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        npm publish --provenance --tag ${TAG:-latest}
     - name: Mark package as deprecated on npm
       run: |
         VERSION="${GITHUB_REF_NAME#v}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine as builder
+FROM node:22.22-alpine3.23 AS builder
 
 WORKDIR /unleash-proxy
 
@@ -6,7 +6,7 @@ COPY . .
 
 RUN corepack enable
 
-ENV YARN_ENABLE_SCRIPTS=false
+ENV YARN_ENABLE_SCRIPTS false
 
 RUN yarn install --immutable
 
@@ -14,7 +14,7 @@ RUN yarn build
 
 RUN yarn workspaces focus -A --production
 
-FROM node:20-alpine
+FROM node:22.22-alpine3.23
 
 # Upgrade (addresses OpenSSL CVE-2023-6237 && CVE-2024-2511)
 RUN apk update && \

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unleash/proxy",
-  "version": "1.4.16",
+  "version": "1.4.17",
   "description": "The Unleash Proxy (Open-Source)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This updates the npm publish workflow, bumps the package.json version and upgrades the docker image.