### PR TITLE
fix: bump alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.22-alpine3.23 AS builder
+FROM node:22.22.3-alpine3.23 AS builder
 
 WORKDIR /unleash-proxy
 
@@ -14,7 +14,7 @@ RUN yarn build
 
 RUN yarn workspaces focus -A --production
 
-FROM node:22.22-alpine3.23
+FROM node:22.22.3-alpine3.23
 
 # Upgrade (addresses OpenSSL CVE-2023-6237 && CVE-2024-2511)
 RUN apk update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN yarn workspaces focus -A --production
 
 FROM node:22.22.3-alpine3.23
 
-# Upgrade (addresses OpenSSL CVE-2023-6237 && CVE-2024-2511)
+# Upgrade Alpine packages to pick up latest security fixes
 RUN apk update && \
     apk upgrade && \
     apk add tini && \


### PR DESCRIPTION
## What

Bumps the Docker base image from `node:22.22-alpine3.23` to `node:22.22.3-alpine3.23` (both the builder and final stages).

Fixes #232.

## Why
The six CVEs reported in #232 are **not** npm/Yarn dependencies — they're OS/runtime-level C libraries that live inside the image, which is why `yarn npm audit` reports none of them:

| CVE | Library | Source |
|---|---|---|
| CVE-2026-22184 | zlib | Node bundled zlib + Alpine `zlib` |
| CVE-2026-28387/88/89/90 | OpenSSL | Node bundled OpenSSL + Alpine `libssl3`/`libcrypto3` |
| CVE-2026-40200 | musl libc | Alpine C runtime |

This change remediates them at two layers:

- **Node's statically-bundled OpenSSL/zlib** — Node 22.22.3 ships OpenSSL **3.5.6**, the fix for the four OpenSSL CVEs, plus a refreshed bundled zlib. Only a base-image bump can update these.
- **Alpine's shared libs** — the existing `apk upgrade` step (unchanged) pulls Alpine 3.23's patched `openssl 3.5.7-r0`, `musl 1.2.5-r23`  (CVE-2026-40200 backport [confirmed fixed][musl] by Alpine secdb), and `zlib 1.3.2-r0`.


## Verification

```bash
  docker build -t unleash-proxy:pr .
  docker run --rm unleash-proxy:pr node -p process.versions.openssl   # >= 3.5.6
  trivy image --severity HIGH,CRITICAL unleash-proxy:pr               # none of the 6 CVEs
```