### PR TITLE
chore: supply-chain hardening

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 
@@ -21,6 +24,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v6
       with:

--- a/.github/workflows/push-docker-releases.yml
+++ b/.github/workflows/push-docker-releases.yml
@@ -5,12 +5,17 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/push-ecr-releases.yml
+++ b/.github/workflows/push-ecr-releases.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Publish to npm
       uses: actions/setup-node@v6
       with:

--- a/.github/workflows/release_changelog.yml
+++ b/.github/workflows/release_changelog.yml
@@ -4,6 +4,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
   release:
     if: startsWith(github.ref, 'refs/tags/')
@@ -11,6 +14,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Build changelog
         id: github_release
         uses: metcalfc/changelog-generator@v4.3.1

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,6 @@
 nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.12.0.cjs
+
+# Supply-chain hardening: never run dependency build scripts (postinstall etc).
+enableScripts: false


### PR DESCRIPTION
## About the changes

Supply-chain hardening, same pattern as Unleash/unleash-js-sdk#295 and Unleash/unleash-node-sdk#879 (prompted by the recent npm supply-chain attacks, e.g. keyv).

- Dependency build scripts disabled (`enableScripts: false` in `.yarnrc.yml` — yarn 4). The only dep with a build script is `unrs-resolver`; everything works without it. Publishing unaffected: `prepare` (build) runs via npm at publish; CI and Dockerfile already run explicit `yarn build`
- Explicit permissions on workflows that lacked them: `contents: read` on CI and docker-release; `contents: write` on the changelog workflow (it creates GitHub releases and previously relied on repo-default permissions)
- `persist-credentials: false` on all six checkouts — no workflow does git operations after checkout

## Verification

Clean `yarn install --immutable` (build scripts reported as disabled); `yarn build` and full test suite (110 tests) pass.
